### PR TITLE
Remove duplicate header, docs clean up, smart compose improvements

### DIFF
--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -44,7 +44,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> {:ok, result} = #{__MODULE__}.all(conn)
+          iex> {:ok, result} = #{__MODULE__}.all(conn, params)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         apply(ExNylas.Paging, :all, [conn, __MODULE__, unquote(use_cursor_paging), params])
@@ -55,7 +55,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> result = #{__MODULE__}.all!(conn)
+          iex> result = #{__MODULE__}.all!(conn, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -108,7 +108,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> {:ok, result} = #{__MODULE__}.first(conn)
+          iex> {:ok, result} = #{__MODULE__}.first(conn, params)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         res =
@@ -134,7 +134,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> result = #{__MODULE__}.first!(conn)
+          iex> result = #{__MODULE__}.first!(conn, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -152,7 +152,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id)
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id, params)
       """
       def unquote(config.name)(%Conn{} = conn, id, params \\ %{}) do
         Req.new(
@@ -172,7 +172,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn, id)
+          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn, id, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, id, params \\ %{}) do
         case unquote(config.name)(conn, id, params) do
@@ -190,7 +190,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn)
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, params)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         Req.new(
@@ -210,7 +210,7 @@ defmodule ExNylas do
 
       ## Examples
 
-          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn)
+          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do

--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -236,7 +236,7 @@ defmodule ExNylas do
           url: ExNylas.generate_url(conn, unquote(use_admin_url), unquote(object)) <> "/#{id}",
           auth: ExNylas.generate_auth(conn, unquote(header_type)),
           headers: API.base_headers(["content-type": "application/json"]),
-          body: changeset,
+          body: API.process_request_body(changeset),
           decode_body: false,
           params: params
         )

--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -42,8 +42,9 @@ defmodule ExNylas do
       @doc """
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
-      Example
-        {:ok, result} = #{__MODULE__}.all(conn)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.all(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         apply(ExNylas.Paging, :all, [conn, __MODULE__, unquote(use_cursor_paging), params])
@@ -52,8 +53,9 @@ defmodule ExNylas do
       @doc """
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
-      Example
-        result = #{__MODULE__}.all!(conn)
+      ## Examples
+
+          iex> result = #{__MODULE__}.all!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -69,8 +71,9 @@ defmodule ExNylas do
       @doc """
       Create and validate a #{unquote(readable_name)}, use create/update to send to Nylas.
 
-      Example
-        {:ok, result} = #{__MODULE__}.build(payload)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.build(payload)
       """
       def unquote(config.name)(payload) do
         try do
@@ -84,8 +87,9 @@ defmodule ExNylas do
       @doc """
       Create and validate a #{unquote(readable_name)}, use the create/update to send to Nylas.
 
-      Example
-        result = #{__MODULE__}.build(payload)!
+      ## Examples
+
+          iex> result = #{__MODULE__}.build(payload)!
       """
       def unquote("#{config.name}!" |> String.to_atom())(payload) do
         unquote(struct_name)
@@ -102,8 +106,9 @@ defmodule ExNylas do
       @doc """
       Get the first #{unquote(readable_name)}.
 
-      Example
-          {:ok, result} = #{__MODULE__}.first(conn)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.first(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         res =
@@ -127,8 +132,9 @@ defmodule ExNylas do
       @doc """
       Get the first #{unquote(readable_name)}.
 
-      Example
-          result = #{__MODULE__}.first!(conn)
+      ## Examples
+
+          iex> result = #{__MODULE__}.first!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -144,8 +150,9 @@ defmodule ExNylas do
       @doc """
       #{unquote(config.name) |> to_string |> String.capitalize()} a(n) #{unquote(readable_name)}.
 
-      Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id)
       """
       def unquote(config.name)(%Conn{} = conn, id, params \\ %{}) do
         Req.new(
@@ -163,8 +170,9 @@ defmodule ExNylas do
       @doc """
       #{unquote(config.name) |> to_string |> String.capitalize()} a(n) #{unquote(readable_name)}.
 
-      Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(conn, id)
+      ## Examples
+
+          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn, id)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, id, params \\ %{}) do
         case unquote(config.name)(conn, id, params) do
@@ -180,8 +188,9 @@ defmodule ExNylas do
       @doc """
       Fetch #{unquote(readable_name)}(s), optionally provide query params.
 
-      Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         Req.new(
@@ -199,8 +208,9 @@ defmodule ExNylas do
       @doc """
       Fetch #{unquote(readable_name)}(s), optionally provide query params.
 
-      Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(conn)
+      ## Examples
+
+          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -216,8 +226,9 @@ defmodule ExNylas do
       @doc """
       Update a(n) #{unquote(readable_name)}.
 
-      Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id, body, params)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id, body, params)
       """
       def unquote(config.name)(%Conn{} = conn, id, changeset, params \\ %{}) do
         Req.new(
@@ -236,8 +247,9 @@ defmodule ExNylas do
       @doc """
       Update a(n) #{unquote(readable_name)}.
 
-      Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(conn, id, body, params)
+      ## Examples
+
+          iex> result = #{__MODULE__}.#{unquote(config.name)}!(conn, id, body, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, id, changeset, params \\ %{}) do
         case unquote(config.name)(conn, id, changeset, params) do
@@ -253,8 +265,9 @@ defmodule ExNylas do
       @doc """
       Create a(n) #{unquote(readable_name)}.
 
-      Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
+      ## Examples
+
+          iex> {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
       """
       def unquote(config.name)(%Conn{} = conn, body, params \\ %{}) do
         Req.new(
@@ -273,8 +286,9 @@ defmodule ExNylas do
       @doc """
       Create a(n) #{unquote(readable_name)}.
 
-      Example
-          result = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
+      ## Examples
+
+          iex> result = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, body, params \\ %{}) do
         case unquote(config.name)(conn, body, params) do

--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -43,7 +43,7 @@ defmodule ExNylas do
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
       Example
-        {:ok, result} = #{__MODULE__}.all(`conn`)
+        {:ok, result} = #{__MODULE__}.all(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         apply(ExNylas.Paging, :all, [conn, __MODULE__, unquote(use_cursor_paging), params])
@@ -53,7 +53,7 @@ defmodule ExNylas do
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
       Example
-        result = #{__MODULE__}.all!(`conn`)
+        result = #{__MODULE__}.all!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -67,10 +67,10 @@ defmodule ExNylas do
   defp generate_api(%{name: :build} = config, _object, struct_name, readable_name, _header_type, _use_admin_url, _use_cursor_paging) do
     quote do
       @doc """
-      Create and validate a #{unquote(readable_name)}, use the save function to send to Nylas.
+      Create and validate a #{unquote(readable_name)}, use create/update to send to Nylas.
 
       Example
-        {:ok, result} = #{__MODULE__}.build(`payload`)
+        {:ok, result} = #{__MODULE__}.build(payload)
       """
       def unquote(config.name)(payload) do
         try do
@@ -82,10 +82,10 @@ defmodule ExNylas do
       end
 
       @doc """
-      Create and validate a #{unquote(readable_name)}, use the save function to send to Nylas.
+      Create and validate a #{unquote(readable_name)}, use the create/update to send to Nylas.
 
       Example
-        result = #{__MODULE__}.build(`payload`)!
+        result = #{__MODULE__}.build(payload)!
       """
       def unquote("#{config.name}!" |> String.to_atom())(payload) do
         unquote(struct_name)
@@ -103,7 +103,7 @@ defmodule ExNylas do
       Get the first #{unquote(readable_name)}.
 
       Example
-          {:ok, result} = #{__MODULE__}.first(`conn`)
+          {:ok, result} = #{__MODULE__}.first(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         res =
@@ -128,7 +128,7 @@ defmodule ExNylas do
       Get the first #{unquote(readable_name)}.
 
       Example
-          result = #{__MODULE__}.first!(`conn`)
+          result = #{__MODULE__}.first!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -145,7 +145,7 @@ defmodule ExNylas do
       #{unquote(config.name) |> to_string |> String.capitalize()} a(n) #{unquote(readable_name)}.
 
       Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(`conn`, `id`)
+          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id)
       """
       def unquote(config.name)(%Conn{} = conn, id, params \\ %{}) do
         Req.new(
@@ -164,7 +164,7 @@ defmodule ExNylas do
       #{unquote(config.name) |> to_string |> String.capitalize()} a(n) #{unquote(readable_name)}.
 
       Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(`conn`, `id`)
+          result = #{__MODULE__}.#{unquote(config.name)}!(conn, id)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, id, params \\ %{}) do
         case unquote(config.name)(conn, id, params) do
@@ -178,10 +178,10 @@ defmodule ExNylas do
   defp generate_api(%{http_method: :get} = config, object, struct_name, readable_name, header_type, use_admin_url, _use_cursor_paging) do
     quote do
       @doc """
-      Fetch #{unquote(readable_name)}(s), optionally provide query `params`.
+      Fetch #{unquote(readable_name)}(s), optionally provide query params.
 
       Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(`conn`)
+          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn)
       """
       def unquote(config.name)(%Conn{} = conn, params \\ %{}) do
         Req.new(
@@ -197,10 +197,10 @@ defmodule ExNylas do
       end
 
       @doc """
-      Fetch #{unquote(readable_name)}(s), optionally provide query `params`.
+      Fetch #{unquote(readable_name)}(s), optionally provide query params.
 
       Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(`conn`)
+          result = #{__MODULE__}.#{unquote(config.name)}!(conn)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ %{}) do
         case unquote(config.name)(conn, params) do
@@ -217,7 +217,7 @@ defmodule ExNylas do
       Update a(n) #{unquote(readable_name)}.
 
       Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(`conn`, `id`, `body`, `params`)
+          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, id, body, params)
       """
       def unquote(config.name)(%Conn{} = conn, id, changeset, params \\ %{}) do
         Req.new(
@@ -237,7 +237,7 @@ defmodule ExNylas do
       Update a(n) #{unquote(readable_name)}.
 
       Example
-          result = #{__MODULE__}.#{unquote(config.name)}!(`conn`, `id`, `body`, `params`)
+          result = #{__MODULE__}.#{unquote(config.name)}!(conn, id, body, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, id, changeset, params \\ %{}) do
         case unquote(config.name)(conn, id, changeset, params) do
@@ -254,7 +254,7 @@ defmodule ExNylas do
       Create a(n) #{unquote(readable_name)}.
 
       Example
-          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(`conn`, `body`, `params`)
+          {:ok, result} = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
       """
       def unquote(config.name)(%Conn{} = conn, body, params \\ %{}) do
         Req.new(
@@ -274,7 +274,7 @@ defmodule ExNylas do
       Create a(n) #{unquote(readable_name)}.
 
       Example
-          result = #{__MODULE__}.#{unquote(config.name)}(`conn`, `body`, `params`)
+          result = #{__MODULE__}.#{unquote(config.name)}(conn, body, params)
       """
       def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, body, params \\ %{}) do
         case unquote(config.name)(conn, body, params) do

--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -275,7 +275,7 @@ defmodule ExNylas do
           url: ExNylas.generate_url(conn, unquote(use_admin_url), unquote(object)),
           auth: ExNylas.generate_auth(conn, unquote(header_type)),
           headers: API.base_headers(["content-type": "application/json"]),
-          body: body,
+          body: API.process_request_body(body),
           decode_body: false,
           params: params
         )

--- a/lib/ex_nylas/attachments.ex
+++ b/lib/ex_nylas/attachments.ex
@@ -36,7 +36,7 @@ defmodule ExNylas.Attachments do
 
   ## Examples
 
-      iex> result = ExNylas.Attachments.download!(conn, id, %{message_id: `message_id`})
+      iex> result = ExNylas.Attachments.download!(conn, id, message_id)
   """
   def download!(%Conn{} = conn, id, message_id) do
     case download(conn, id, message_id) do

--- a/lib/ex_nylas/attachments.ex
+++ b/lib/ex_nylas/attachments.ex
@@ -16,7 +16,7 @@ defmodule ExNylas.Attachments do
   Download an attachment.
 
   Example
-      {:ok, result} = ExNylas.Attachments.download(conn, `id`, `message_id`)
+      {:ok, result} = ExNylas.Attachments.download(conn, id, message_id)
   """
   def download(%Conn{} = conn, id, message_id) do
     Req.new(
@@ -34,7 +34,7 @@ defmodule ExNylas.Attachments do
   Download an attachment.
 
   Example
-      result = ExNylas.Attachments.download!(conn, `id`, %{message_id: `message_id`})
+      result = ExNylas.Attachments.download!(conn, id, %{message_id: `message_id`})
   """
   def download!(%Conn{} = conn, id, message_id) do
     case download(conn, id, message_id) do

--- a/lib/ex_nylas/attachments.ex
+++ b/lib/ex_nylas/attachments.ex
@@ -15,8 +15,9 @@ defmodule ExNylas.Attachments do
   @doc """
   Download an attachment.
 
-  Example
-      {:ok, result} = ExNylas.Attachments.download(conn, id, message_id)
+  ## Examples
+
+      iex> {:ok, result} = ExNylas.Attachments.download(conn, id, message_id)
   """
   def download(%Conn{} = conn, id, message_id) do
     Req.new(
@@ -33,8 +34,9 @@ defmodule ExNylas.Attachments do
   @doc """
   Download an attachment.
 
-  Example
-      result = ExNylas.Attachments.download!(conn, id, %{message_id: `message_id`})
+  ## Examples
+
+      iex> result = ExNylas.Attachments.download!(conn, id, %{message_id: `message_id`})
   """
   def download!(%Conn{} = conn, id, message_id) do
     case download(conn, id, message_id) do

--- a/lib/ex_nylas/availability.ex
+++ b/lib/ex_nylas/availability.ex
@@ -14,8 +14,9 @@ defmodule ExNylas.Calendars.Availability do
   @doc """
   Get calendar availability.
 
-  Example
-      {:ok, result} = ExNylas.Calendars.Availability.list(conn, body)
+  ## Examples
+
+      iex> {:ok, result} = ExNylas.Calendars.Availability.list(conn, body)
   """
   def list(%Conn{} = conn, body) do
     Req.new(
@@ -32,8 +33,9 @@ defmodule ExNylas.Calendars.Availability do
   @doc """
   Get calendar availability.
 
-  Example
-      result = ExNylas.Calendars.Availability.list!(conn, body)
+  ## Examples
+
+      iex> result = ExNylas.Calendars.Availability.list!(conn, body)
   """
   def list!(%Conn{} = conn, body) do
     case list(conn, body) do

--- a/lib/ex_nylas/availability.ex
+++ b/lib/ex_nylas/availability.ex
@@ -15,7 +15,7 @@ defmodule ExNylas.Calendars.Availability do
   Get calendar availability.
 
   Example
-      {:ok, result} = ExNylas.Calendars.Availability.list(conn, `body`)
+      {:ok, result} = ExNylas.Calendars.Availability.list(conn, body)
   """
   def list(%Conn{} = conn, body) do
     Req.new(
@@ -33,7 +33,7 @@ defmodule ExNylas.Calendars.Availability do
   Get calendar availability.
 
   Example
-      result = ExNylas.Calendars.Availability.list!(conn, `body`)
+      result = ExNylas.Calendars.Availability.list!(conn, body)
   """
   def list!(%Conn{} = conn, body) do
     case list(conn, body) do

--- a/lib/ex_nylas/connector_credentials.ex
+++ b/lib/ex_nylas/connector_credentials.ex
@@ -132,8 +132,9 @@ defmodule ExNylas.ConnectorCredentials do
   @doc """
   Update a connector credential.
 
-  Example
-      {:ok, cred} = ExNylas.ConnectorCredentials.update(conn, provider, id, changeset)
+  ## Examples
+
+      iex> {:ok, cred} = ExNylas.ConnectorCredentials.update(conn, provider, id, changeset)
   """
   def update(%Conn{} = conn, provider, id, changeset) do
     Req.new(
@@ -150,8 +151,9 @@ defmodule ExNylas.ConnectorCredentials do
   @doc """
   Update a connector credential.
 
-  Example
-      cred = ExNylas.ConnectorCredentials.update!(conn, provider, id, changeset)
+  ## Examples
+
+      iex> cred = ExNylas.ConnectorCredentials.update!(conn, provider, id, changeset)
   """
   def update!(%Conn{} = conn, provider, id, changeset) do
     case update(conn, provider, id, changeset) do

--- a/lib/ex_nylas/connector_credentials.ex
+++ b/lib/ex_nylas/connector_credentials.ex
@@ -11,7 +11,7 @@ defmodule ExNylas.ConnectorCredentials do
   List connector credentials.
 
   Example
-      {:ok, creds} = ExNylas.ConnectorCredentials.list(conn, `provider`)
+      {:ok, creds} = ExNylas.ConnectorCredentials.list(conn, provider)
   """
   def list(%Conn{} = conn, provider, params \\ %{}) do
     Req.new(
@@ -29,7 +29,7 @@ defmodule ExNylas.ConnectorCredentials do
   List connector credentials.
 
   Example
-      creds = ExNylas.ConnectorCredentials.list!(conn, `provider`)
+      creds = ExNylas.ConnectorCredentials.list!(conn, provider)
   """
   def list!(%Conn{} = conn, provider, params \\ %{}) do
     case list(conn, provider, params) do
@@ -42,7 +42,7 @@ defmodule ExNylas.ConnectorCredentials do
   Create a connector credential.
 
   Example
-      {:ok, cred} = ExNylas.ConnectorCredentials.create(conn, `provider`, `body`)
+      {:ok, cred} = ExNylas.ConnectorCredentials.create(conn, provider, body)
   """
   def create(%Conn{} = conn, provider, body) do
     Req.new(
@@ -60,7 +60,7 @@ defmodule ExNylas.ConnectorCredentials do
   Create a connector credential.
 
   Example
-      cred = ExNylas.ConnectorCredentials.create!(conn, `provider`, `body`)
+      cred = ExNylas.ConnectorCredentials.create!(conn, provider, body)
   """
   def create!(%Conn{} = conn, provider, body) do
     case create(conn, provider, body) do
@@ -73,7 +73,7 @@ defmodule ExNylas.ConnectorCredentials do
   Find a connector credential.
 
   Example
-      {:ok, cred} = ExNylas.ConnectorCredentials.find(conn, `provider`, `id`)
+      {:ok, cred} = ExNylas.ConnectorCredentials.find(conn, provider, id)
   """
   def find(%Conn{} = conn, provider, id) do
     Req.new(
@@ -90,7 +90,7 @@ defmodule ExNylas.ConnectorCredentials do
   Find a connector credential.
 
   Example
-      cred = ExNylas.ConnectorCredentials.find(conn, `provider`, `id`)
+      cred = ExNylas.ConnectorCredentials.find(conn, provider, id)
   """
   def find!(%Conn{} = conn, provider, id) do
     case find(conn, provider, id) do
@@ -103,7 +103,7 @@ defmodule ExNylas.ConnectorCredentials do
   Delete a connector credential.
 
   Example
-      {:ok, res} = ExNylas.ConnectorCredentials.delete(conn, `provider`, `id`)
+      {:ok, res} = ExNylas.ConnectorCredentials.delete(conn, provider, id)
   """
   def delete(%Conn{} = conn, provider, id) do
     Req.new(
@@ -120,7 +120,7 @@ defmodule ExNylas.ConnectorCredentials do
   Delete a connector credential.
 
   Example
-      res = ExNylas.ConnectorCredentials.delete!(conn, `provider`, `id`)
+      res = ExNylas.ConnectorCredentials.delete!(conn, provider, id)
   """
   def delete!(%Conn{} = conn, provider, id) do
     case delete(conn, provider, id) do
@@ -133,7 +133,7 @@ defmodule ExNylas.ConnectorCredentials do
   Update a connector credential.
 
   Example
-      {:ok, cred} = ExNylas.ConnectorCredentials.update(conn, `provider`, `id`, `changeset`)
+      {:ok, cred} = ExNylas.ConnectorCredentials.update(conn, provider, id, changeset)
   """
   def update(%Conn{} = conn, provider, id, changeset) do
     Req.new(
@@ -151,7 +151,7 @@ defmodule ExNylas.ConnectorCredentials do
   Update a connector credential.
 
   Example
-      cred = ExNylas.ConnectorCredentials.update!(conn, `provider`, `id`, `changeset`)
+      cred = ExNylas.ConnectorCredentials.update!(conn, provider, id, changeset)
   """
   def update!(%Conn{} = conn, provider, id, changeset) do
     case update(conn, provider, id, changeset) do

--- a/lib/ex_nylas/contacts.ex
+++ b/lib/ex_nylas/contacts.ex
@@ -7,6 +7,6 @@ defmodule ExNylas.Contacts do
     object: "contacts",
     struct: ExNylas.Model.Contact,
     readable_name: "contact",
-    include: [:list, :first, :find, :update, :delete, :build, :all]
+    include: [:list, :first, :find, :update, :delete, :build, :all, :create]
 
 end

--- a/lib/ex_nylas/custom_authentication.ex
+++ b/lib/ex_nylas/custom_authentication.ex
@@ -10,7 +10,7 @@ defmodule ExNylas.CustomAuthentication do
   Connect a grant using custom authentication.
 
   Example
-      {:ok, grant} = ExNylas.CustomAuthentication.connect(conn, `body`)
+      {:ok, grant} = ExNylas.CustomAuthentication.connect(conn, body)
   """
   def connect(%Conn{} = conn, body) do
     Req.new(
@@ -28,7 +28,7 @@ defmodule ExNylas.CustomAuthentication do
   Connect a grant using custom authentication.
 
   Example
-      grant = ExNylas.CustomAuthentication.connect!(conn, `body`)
+      grant = ExNylas.CustomAuthentication.connect!(conn, body)
   """
   def connect!(%Conn{} = conn, body) do
     case connect(conn, body) do

--- a/lib/ex_nylas/custom_authentication.ex
+++ b/lib/ex_nylas/custom_authentication.ex
@@ -9,8 +9,9 @@ defmodule ExNylas.CustomAuthentication do
   @doc """
   Connect a grant using custom authentication.
 
-  Example
-      {:ok, grant} = ExNylas.CustomAuthentication.connect(conn, body)
+  ## Examples
+
+      iex> {:ok, grant} = ExNylas.CustomAuthentication.connect(conn, body)
   """
   def connect(%Conn{} = conn, body) do
     Req.new(
@@ -27,8 +28,9 @@ defmodule ExNylas.CustomAuthentication do
   @doc """
   Connect a grant using custom authentication.
 
-  Example
-      grant = ExNylas.CustomAuthentication.connect!(conn, body)
+  ## Examples
+
+      iex> grant = ExNylas.CustomAuthentication.connect!(conn, body)
   """
   def connect!(%Conn{} = conn, body) do
     case connect(conn, body) do

--- a/lib/ex_nylas/drafts.ex
+++ b/lib/ex_nylas/drafts.ex
@@ -19,7 +19,7 @@ defmodule ExNylas.Drafts do
   Create a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
   Example
-      {:ok, draft} = ExNylas.Drafts.create(conn, `draft`, `["path_to_attachment"]`)
+      {:ok, draft} = ExNylas.Drafts.create(conn, draft, ["path_to_attachment"])
   """
   def create(%Conn{} = conn, draft, attachments \\ []) do
     {body, content_type, len} = API.build_multipart(draft, attachments)
@@ -39,7 +39,7 @@ defmodule ExNylas.Drafts do
   Create a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
   Example
-      draft = ExNylas.Drafts.create!(conn, `draft`, `["path_to_attachment"]`)
+      draft = ExNylas.Drafts.create!(conn, draft, ["path_to_attachment"])
   """
   def create!(%Conn{} = conn, draft, attachments \\ []) do
     case create(conn, draft, attachments) do
@@ -51,10 +51,10 @@ defmodule ExNylas.Drafts do
   @doc """
   Update a draft.
 
-  To add attachments greater than 3MB, use update/4 or update!/4.
+  To add attachments greater than 3MB, use `update/4` or `update!/4`.
 
   Example
-      {:ok, draft} = ExNylas.Drafts.update(conn, `id`, `changeset`)
+      {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset)
   """
   def update(%Conn{} = conn, id, changeset) do
     Req.new(
@@ -71,10 +71,10 @@ defmodule ExNylas.Drafts do
   @doc """
   Update a draft.
 
-  To add attachments greater than 3MB, use update/4 or update!/4.
+  To add attachments greater than 3MB, use `update/4` or `update!/4`.
 
   Example
-      draft = ExNylas.Drafts.update!(conn, `id`, `changeset`)
+      draft = ExNylas.Drafts.update!(conn, id, changeset)
   """
   def update!(%Conn{} = conn, id, changeset) do
     case update(conn, id, changeset) do
@@ -86,10 +86,10 @@ defmodule ExNylas.Drafts do
   @doc """
   Update a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  To remove all attachments from a draft, use update/3 or update!/3.
+  To remove all attachments from a draft, use `update/3` or `update!/3`.
 
   Example
-      {:ok, draft} = ExNylas.Drafts.update(conn, `id`, `changeset`, `["path_to_attachment"]`)
+      {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset, ["path_to_attachment"])
   """
   def update(%Conn{} = conn, id, changeset, attachments) do
     {body, content_type, len} = API.build_multipart(changeset, attachments)
@@ -108,10 +108,10 @@ defmodule ExNylas.Drafts do
   @doc """
   Update a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  To remove all attachments from a draft, use update/3 or update!/3.
+  To remove all attachments from a draft, use `update/3` or `update!/3`.
 
   Example
-      draft = ExNylas.Drafts.update!(conn, `id`, `changeset`, `["path_to_attachment"]`)
+      draft = ExNylas.Drafts.update!(conn, id, changeset, ["path_to_attachment"])
   """
   def update!(%Conn{} = conn, id, changeset, attachments) do
     case update(conn, id, changeset, attachments) do
@@ -124,7 +124,7 @@ defmodule ExNylas.Drafts do
   Send a draft.
 
   Example
-      {:ok, sent_draft} = ExNylas.Drafts.send(conn, `draft_id`)
+      {:ok, sent_draft} = ExNylas.Drafts.send(conn, draft_id)
   """
   def send(%Conn{} = conn, draft_id) do
     Req.new(
@@ -141,7 +141,7 @@ defmodule ExNylas.Drafts do
   Send a draft.
 
   Example
-      sent_draft = ExNylas.Drafts.send!(conn, `draft_id`)
+      sent_draft = ExNylas.Drafts.send!(conn, draft_id)
   """
   def send!(%Conn{} = conn, draft_id) do
     case send(conn, draft_id) do

--- a/lib/ex_nylas/drafts.ex
+++ b/lib/ex_nylas/drafts.ex
@@ -135,7 +135,7 @@ defmodule ExNylas.Drafts do
   """
   def send(%Conn{} = conn, draft_id) do
     Req.new(
-      url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/drafts/#{draft_id}/send",
+      url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/drafts/#{draft_id}",
       auth: API.auth_bearer(conn),
       headers: API.base_headers(),
       decode_body: false

--- a/lib/ex_nylas/drafts.ex
+++ b/lib/ex_nylas/drafts.ex
@@ -18,8 +18,9 @@ defmodule ExNylas.Drafts do
   @doc """
   Create a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  Example
-      {:ok, draft} = ExNylas.Drafts.create(conn, draft, ["path_to_attachment"])
+  ## Examples
+
+      iex> {:ok, draft} = ExNylas.Drafts.create(conn, draft, ["path_to_attachment"])
   """
   def create(%Conn{} = conn, draft, attachments \\ []) do
     {body, content_type, len} = API.build_multipart(draft, attachments)
@@ -38,8 +39,9 @@ defmodule ExNylas.Drafts do
   @doc """
   Create a draft.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  Example
-      draft = ExNylas.Drafts.create!(conn, draft, ["path_to_attachment"])
+  ## Examples
+
+      iex> draft = ExNylas.Drafts.create!(conn, draft, ["path_to_attachment"])
   """
   def create!(%Conn{} = conn, draft, attachments \\ []) do
     case create(conn, draft, attachments) do
@@ -53,8 +55,9 @@ defmodule ExNylas.Drafts do
 
   To add attachments greater than 3MB, use `update/4` or `update!/4`.
 
-  Example
-      {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset)
+  ## Examples
+
+      iex> {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset)
   """
   def update(%Conn{} = conn, id, changeset) do
     Req.new(
@@ -73,8 +76,9 @@ defmodule ExNylas.Drafts do
 
   To add attachments greater than 3MB, use `update/4` or `update!/4`.
 
-  Example
-      draft = ExNylas.Drafts.update!(conn, id, changeset)
+  ## Examples
+
+      iex> draft = ExNylas.Drafts.update!(conn, id, changeset)
   """
   def update!(%Conn{} = conn, id, changeset) do
     case update(conn, id, changeset) do
@@ -88,8 +92,9 @@ defmodule ExNylas.Drafts do
 
   To remove all attachments from a draft, use `update/3` or `update!/3`.
 
-  Example
-      {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset, ["path_to_attachment"])
+  ## Examples
+
+      iex> {:ok, draft} = ExNylas.Drafts.update(conn, id, changeset, ["path_to_attachment"])
   """
   def update(%Conn{} = conn, id, changeset, attachments) do
     {body, content_type, len} = API.build_multipart(changeset, attachments)
@@ -110,8 +115,9 @@ defmodule ExNylas.Drafts do
 
   To remove all attachments from a draft, use `update/3` or `update!/3`.
 
-  Example
-      draft = ExNylas.Drafts.update!(conn, id, changeset, ["path_to_attachment"])
+  ## Examples
+
+      iex> draft = ExNylas.Drafts.update!(conn, id, changeset, ["path_to_attachment"])
   """
   def update!(%Conn{} = conn, id, changeset, attachments) do
     case update(conn, id, changeset, attachments) do
@@ -123,8 +129,9 @@ defmodule ExNylas.Drafts do
   @doc """
   Send a draft.
 
-  Example
-      {:ok, sent_draft} = ExNylas.Drafts.send(conn, draft_id)
+  ## Examples
+
+      iex> {:ok, sent_draft} = ExNylas.Drafts.send(conn, draft_id)
   """
   def send(%Conn{} = conn, draft_id) do
     Req.new(
@@ -140,8 +147,9 @@ defmodule ExNylas.Drafts do
   @doc """
   Send a draft.
 
-  Example
-      sent_draft = ExNylas.Drafts.send!(conn, draft_id)
+  ## Examples
+
+      iex> sent_draft = ExNylas.Drafts.send!(conn, draft_id)
   """
   def send!(%Conn{} = conn, draft_id) do
     case send(conn, draft_id) do

--- a/lib/ex_nylas/events.ex
+++ b/lib/ex_nylas/events.ex
@@ -17,7 +17,7 @@ defmodule ExNylas.Events do
   Send an RSVP for a given event
 
   Example
-      {:ok, success} = ExNylas.Events.rsvp(conn, `event_id`, `status`, `calendar_id`)
+      {:ok, success} = ExNylas.Events.rsvp(conn, event_id, status, calendar_id)
   """
   def rsvp(%Conn{} = conn, event_id, status, calendar_id) do
     Req.new(
@@ -36,7 +36,7 @@ defmodule ExNylas.Events do
   Send an RSVP for a given event
 
   Example
-      success = ExNylas.Events.rsvp!(conn, `event_id`, `status`, `calendar_id`)
+      success = ExNylas.Events.rsvp!(conn, event_id, status, calendar_id)
   """
   def rsvp!(%Conn{} = conn, event_id, status, calendar_id) do
     case rsvp(conn, event_id, status, calendar_id) do

--- a/lib/ex_nylas/events.ex
+++ b/lib/ex_nylas/events.ex
@@ -23,7 +23,7 @@ defmodule ExNylas.Events do
     Req.new(
       url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/events/#{event_id}/send-rsvp",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json"]),
+      headers: API.base_headers(),
       json: %{status: status, calendar_id: calendar_id},
       decode_body: false,
       params: %{calendar_id: calendar_id}

--- a/lib/ex_nylas/events.ex
+++ b/lib/ex_nylas/events.ex
@@ -16,8 +16,9 @@ defmodule ExNylas.Events do
   @doc """
   Send an RSVP for a given event
 
-  Example
-      {:ok, success} = ExNylas.Events.rsvp(conn, event_id, status, calendar_id)
+  ## Examples
+
+      iex> {:ok, success} = ExNylas.Events.rsvp(conn, event_id, status, calendar_id)
   """
   def rsvp(%Conn{} = conn, event_id, status, calendar_id) do
     Req.new(
@@ -35,8 +36,9 @@ defmodule ExNylas.Events do
   @doc """
   Send an RSVP for a given event
 
-  Example
-      success = ExNylas.Events.rsvp!(conn, event_id, status, calendar_id)
+  ## Examples
+
+      iex> success = ExNylas.Events.rsvp!(conn, event_id, status, calendar_id)
   """
   def rsvp!(%Conn{} = conn, event_id, status, calendar_id) do
     case rsvp(conn, event_id, status, calendar_id) do

--- a/lib/ex_nylas/free_busy.ex
+++ b/lib/ex_nylas/free_busy.ex
@@ -15,7 +15,7 @@ defmodule ExNylas.Calendars.FreeBusy do
   Get calendar free/busy.
 
   Example
-      {:ok, result} = ExNylas.Calendars.FreeBusy.list(conn, `body`)
+      {:ok, result} = ExNylas.Calendars.FreeBusy.list(conn, body)
   """
   def list(%Conn{} = conn, body) do
     Req.new(
@@ -33,7 +33,7 @@ defmodule ExNylas.Calendars.FreeBusy do
   Get calendar free/busy.
 
   Example
-      result = ExNylas.Calendars.FreeBusy.list!(conn, `body`)
+      result = ExNylas.Calendars.FreeBusy.list!(conn, body)
   """
   def list!(%Conn{} = conn, body) do
     case list(conn, body) do

--- a/lib/ex_nylas/free_busy.ex
+++ b/lib/ex_nylas/free_busy.ex
@@ -14,8 +14,9 @@ defmodule ExNylas.Calendars.FreeBusy do
   @doc """
   Get calendar free/busy.
 
-  Example
-      {:ok, result} = ExNylas.Calendars.FreeBusy.list(conn, body)
+  ## Examples
+
+      iex> {:ok, result} = ExNylas.Calendars.FreeBusy.list(conn, body)
   """
   def list(%Conn{} = conn, body) do
     Req.new(
@@ -32,8 +33,9 @@ defmodule ExNylas.Calendars.FreeBusy do
   @doc """
   Get calendar free/busy.
 
-  Example
-      result = ExNylas.Calendars.FreeBusy.list!(conn, body)
+  ## Examples
+
+      iex> result = ExNylas.Calendars.FreeBusy.list!(conn, body)
   """
   def list!(%Conn{} = conn, body) do
     case list(conn, body) do

--- a/lib/ex_nylas/grants.ex
+++ b/lib/ex_nylas/grants.ex
@@ -17,8 +17,9 @@ defmodule ExNylas.Grants do
   @doc """
   Get a grant using the current access token.
 
-  Example
-      {:ok, result} = ExNylas.Grants.me(conn)
+  ## Examples
+
+      iex> {:ok, result} = ExNylas.Grants.me(conn)
   """
   def me(%Conn{} = conn) do
     Req.new(

--- a/lib/ex_nylas/hosted_authentication.ex
+++ b/lib/ex_nylas/hosted_authentication.ex
@@ -66,7 +66,7 @@ defmodule ExNylas.HostedAuthentication do
   def exchange_code_for_token(%Conn{} = conn, code, redirect_uri, grant_type \\ "authorization_code") do
     Req.new(
       url: "#{conn.api_server}/v3/connect/token",
-      headers: API.base_headers(["content-type": "application/json"]),
+      headers: API.base_headers(),
       json: %{
         client_id: conn.client_id,
         client_secret: conn.client_secret,

--- a/lib/ex_nylas/hosted_authentication.ex
+++ b/lib/ex_nylas/hosted_authentication.ex
@@ -14,9 +14,10 @@ defmodule ExNylas.HostedAuthentication do
     2. `redirect_uri` is required (on the options map) and must be registered on the Nylas application
     3. `response_type` is required (on the options map)
 
-  Example
-      options = %{login_hint: "hello@nylas.com", redirect_uri: "https://mycoolapp.com/auth", state: "random_string", scope: ["provider_scope_1", "provider_scope_2"]}
-      {:ok, uri} = ExNylas.HostedAuthentication.get_auth_url(conn, options)
+  ## Examples
+
+      iex> options = %{login_hint: "hello@nylas.com", redirect_uri: "https://mycoolapp.com/auth", state: "random_string", scope: ["provider_scope_1", "provider_scope_2"]}
+      iex> {:ok, uri} = ExNylas.HostedAuthentication.get_auth_url(conn, options)
   """
   def get_auth_url(%Conn{} = conn, options) do
     url =
@@ -46,9 +47,10 @@ defmodule ExNylas.HostedAuthentication do
     2. `redirect_uri` is required (on the options map) and must be registered on the Nylas application
     3. `response_type` is required (on the options map)
 
-  Example
-      options = %{login_hint: "hello@nylas.com", redirect_uri: "https://mycoolapp.com/auth", state: "random_string", scope: ["provider_scope_1", "provider_scope_2"]}
-      uri = ExNylas.HostedAuthentication.get_auth_url!(conn, options)
+  ## Examples
+
+      iex> options = %{login_hint: "hello@nylas.com", redirect_uri: "https://mycoolapp.com/auth", state: "random_string", scope: ["provider_scope_1", "provider_scope_2"]}
+      iex> uri = ExNylas.HostedAuthentication.get_auth_url!(conn, options)
   """
   def get_auth_url!(%Conn{} = conn, options) do
     case get_auth_url(conn, options) do
@@ -60,8 +62,9 @@ defmodule ExNylas.HostedAuthentication do
   @doc """
   Exchange an authorization code for a Nylas access token
 
-  Example
-      {:ok, access_token} = ExNylas.HostedAuthentication.exchange_code_for_token(conn, code, redirect)
+  ## Examples
+
+      iex> {:ok, access_token} = ExNylas.HostedAuthentication.exchange_code_for_token(conn, code, redirect)
   """
   def exchange_code_for_token(%Conn{} = conn, code, redirect_uri, grant_type \\ "authorization_code") do
     Req.new(
@@ -83,8 +86,9 @@ defmodule ExNylas.HostedAuthentication do
   @doc """
   Exchange an authorization code for a Nylas access token
 
-  Example
-      access_token = ExNylas.HostedAuthentication.exchange_code_for_token!(conn, code, redirect)
+  ## Examples
+
+      iex> access_token = ExNylas.HostedAuthentication.exchange_code_for_token!(conn, code, redirect)
   """
   def exchange_code_for_token!(%Conn{} = conn, code, redirect_uri, grant_type \\ "authorization_code") do
     case exchange_code_for_token(conn, code, redirect_uri, grant_type) do

--- a/lib/ex_nylas/messages.ex
+++ b/lib/ex_nylas/messages.ex
@@ -19,7 +19,7 @@ defmodule ExNylas.Messages do
   Send a message.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
   Example
-      {:ok, sent_message} = ExNylas.Messages.send(conn, `message`, `["path_to_attachment"]`)
+      {:ok, sent_message} = ExNylas.Messages.send(conn, message, ["path_to_attachment"])
   """
   def send(%Conn{} = conn, message, attachments \\ []) do
     {body, content_type, len} = API.build_multipart(message, attachments)
@@ -39,7 +39,7 @@ defmodule ExNylas.Messages do
   Send a message.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
   Example
-      sent_message = ExNylas.Messages.send!(conn, `message`, `["path_to_attachment"]`)
+      sent_message = ExNylas.Messages.send!(conn, message, ["path_to_attachment"])
   """
   def send!(%Conn{} = conn, message, attachments \\ []) do
     case send(conn, message, attachments) do

--- a/lib/ex_nylas/messages.ex
+++ b/lib/ex_nylas/messages.ex
@@ -18,8 +18,9 @@ defmodule ExNylas.Messages do
   @doc """
   Send a message.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  Example
-      {:ok, sent_message} = ExNylas.Messages.send(conn, message, ["path_to_attachment"])
+  ## Examples
+
+      iex> {:ok, sent_message} = ExNylas.Messages.send(conn, message, ["path_to_attachment"])
   """
   def send(%Conn{} = conn, message, attachments \\ []) do
     {body, content_type, len} = API.build_multipart(message, attachments)
@@ -38,8 +39,9 @@ defmodule ExNylas.Messages do
   @doc """
   Send a message.  Attachments must be either a list of file paths or a list of tuples with the content-id and file path.  The latter of which is needed in order to attach inline images.
 
-  Example
-      sent_message = ExNylas.Messages.send!(conn, message, ["path_to_attachment"])
+  ## Examples
+
+      iex> sent_message = ExNylas.Messages.send!(conn, message, ["path_to_attachment"])
   """
   def send!(%Conn{} = conn, message, attachments \\ []) do
     case send(conn, message, attachments) do

--- a/lib/ex_nylas/model/free_busy.ex
+++ b/lib/ex_nylas/model/free_busy.ex
@@ -9,7 +9,7 @@ defmodule ExNylas.Model.Calendar.FreeBusy do
   typedstruct do
     field(:object, String.t())
     field(:email, String.t())
-    field(:timeslots, [TimeSlot.t()])
+    field(:time_slots, [TimeSlot.t()])
   end
 
   typedstruct module: Build do
@@ -20,7 +20,7 @@ defmodule ExNylas.Model.Calendar.FreeBusy do
 
   def as_struct() do
     %__MODULE__{
-      timeslots: [TimeSlot.as_struct()]
+      time_slots: [TimeSlot.as_struct()]
     }
   end
 

--- a/lib/ex_nylas/model/smart_compose.ex
+++ b/lib/ex_nylas/model/smart_compose.ex
@@ -10,8 +10,4 @@ defmodule ExNylas.Model.SmartCompose do
   end
 
   def as_struct(), do: struct(__MODULE__)
-
-  typedstruct module: Build do
-    field(:prompt, String.t())
-  end
 end

--- a/lib/ex_nylas/providers.ex
+++ b/lib/ex_nylas/providers.ex
@@ -9,8 +9,9 @@ defmodule ExNylas.Providers do
   @doc """
   Detect the provider for an email address.
 
-  Example
-      {:ok,  detect} = ExNylas.Providers.detect(conn, %{email: email} = _params)
+  ## Examples
+
+      iex> {:ok,  detect} = ExNylas.Providers.detect(conn, %{email: email} = _params)
   """
   def detect(%Conn{} = conn, params \\ %{}) do
     Req.new(
@@ -27,8 +28,9 @@ defmodule ExNylas.Providers do
   @doc """
   Detect the provider for an email address.
 
-  Example
-      detect = ExNylas.Providers.detect(conn, %{email: email} = _params)
+  ## Examples
+
+      iex> detect = ExNylas.Providers.detect(conn, %{email: email} = _params)
   """
   def detect!(%Conn{} = conn, params \\ %{}) do
     case detect(conn, params) do

--- a/lib/ex_nylas/providers.ex
+++ b/lib/ex_nylas/providers.ex
@@ -10,7 +10,7 @@ defmodule ExNylas.Providers do
   Detect the provider for an email address.
 
   Example
-      {:ok,  detect} = ExNylas.Providers.detect(conn, %{email: `email`} = _params)
+      {:ok,  detect} = ExNylas.Providers.detect(conn, %{email: email} = _params)
   """
   def detect(%Conn{} = conn, params \\ %{}) do
     Req.new(
@@ -28,7 +28,7 @@ defmodule ExNylas.Providers do
   Detect the provider for an email address.
 
   Example
-      detect = ExNylas.Providers.detect(conn, %{email: `email`} = _params)
+      detect = ExNylas.Providers.detect(conn, %{email: email} = _params)
   """
   def detect!(%Conn{} = conn, params \\ %{}) do
     case detect(conn, params) do

--- a/lib/ex_nylas/smart_compose.ex
+++ b/lib/ex_nylas/smart_compose.ex
@@ -16,7 +16,7 @@ defmodule ExNylas.SmartCompose do
   Smart compose a message reply.
 
   Example
-      {:ok, res} = ExNylas.SmartCompose.create_reply(conn, `message_id`, `prompt`)
+      {:ok, res} = ExNylas.SmartCompose.create_reply(conn, message_id, prompt)
   """
   def create_reply(%Conn{} = conn, message_id, prompt) do
     Req.new(
@@ -34,7 +34,7 @@ defmodule ExNylas.SmartCompose do
   Smart compose a message reply.
 
   Example
-      res = ExNylas.SmartCompose.create_reply!(conn, `message_id`, `prompt`)
+      res = ExNylas.SmartCompose.create_reply!(conn, message_id, prompt)
   """
   def create_reply!(%Conn{} = conn, message_id, prompt) do
     case create_reply(conn, message_id, prompt) do
@@ -49,7 +49,7 @@ defmodule ExNylas.SmartCompose do
   Note - the response is a stream of untransformed events as shown in the example below.
 
   Example
-      ExNylas.SmartCompose.create_stream(conn, `prompt`, `IO.stream()`)
+      ExNylas.SmartCompose.create_stream(conn, prompt, IO.stream())
       data: {"suggestion": ""}
       data: {"suggestion": "Subject"}
       ...
@@ -75,7 +75,7 @@ defmodule ExNylas.SmartCompose do
   Note - the response is a stream of untransformed events as shown in the example below.
 
   Example
-      ExNylas.SmartCompose.create_stream(conn, `message_id`, `prompt`, `IO.stream()`)
+      ExNylas.SmartCompose.create_stream(conn, message_id, prompt, IO.stream())
       data: {"suggestion": ""}
       data: {"suggestion": "Subject"}
       ...

--- a/lib/ex_nylas/smart_compose.ex
+++ b/lib/ex_nylas/smart_compose.ex
@@ -6,11 +6,38 @@ defmodule ExNylas.SmartCompose do
   alias ExNylas.API
   alias ExNylas.Connection, as: Conn
 
-  use ExNylas,
-    object: "messages/smart-compose",
-    struct: ExNylas.Model.SmartCompose,
-    readable_name: "smart compose",
-    include: [:build, :create]
+  @doc """
+  Create a smart compose.
+
+  ## Examples
+
+      iex> {:ok, res} = ExNylas.SmartCompose.create(conn, prompt)
+  """
+  def create(%Conn{} = conn, prompt) do
+    Req.new(
+      url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/messages/smart-compose",
+      auth: API.auth_bearer(conn),
+      headers: API.base_headers(),
+      json: %{prompt: prompt},
+      decode_body: false
+    )
+    |> Req.post(conn.options)
+    |> API.handle_response(ExNylas.Model.SmartCompose.as_struct())
+  end
+
+  @doc """
+  Create a smart compose.
+
+  ## Examples
+
+      iex> res = ExNylas.SmartCompose.create!(conn, prompt)
+  """
+  def create!(%Conn{} = conn, prompt) do
+    case create(conn, prompt) do
+      {:ok, res} -> res
+      {:error, reason} -> raise ExNylasError, reason
+    end
+  end
 
   @doc """
   Smart compose a message reply.
@@ -48,16 +75,13 @@ defmodule ExNylas.SmartCompose do
   @doc """
   Smart compose a message with a streaming response.
 
-  Note - the response is a stream of untransformed events as shown in the example below.
+  Note - ExNylas will call the provided function with each transformed chunk of the suggestion as it is received.
 
   ## Examples
 
-      iex> ExNylas.SmartCompose.create_stream(conn, prompt, IO.stream())
-      iex> data: {"suggestion": ""}
-      iex> data: {"suggestion": "Subject"}
-      ...
-      iex> data: {"suggestion": "]"}
-      iex> {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
+      iex> ExNylas.SmartCompose.create_stream(conn, prompt, &IO.write/1)
+      iex> Dear [Recipient], ...
+      iex> {:ok, ""}
   """
   def create_stream(%Conn{} = conn, prompt, stream_to) do
     Req.new(
@@ -65,7 +89,8 @@ defmodule ExNylas.SmartCompose do
       auth: API.auth_bearer(conn),
       headers: API.base_headers([accept: "text/event-stream"]),
       json: %{prompt: prompt},
-      into: stream_to,
+      decode_body: false,
+      into: API.handle_stream(stream_to),
       compressed: false
     )
     |> Req.post(conn.options)
@@ -75,16 +100,13 @@ defmodule ExNylas.SmartCompose do
   @doc """
   Smart compose a reply to a message with a streaming response.
 
-  Note - the response is a stream of untransformed events as shown in the example below.
+  Note - ExNylas will call the provided function with each transformed chunk of the suggestion as it is received.
 
   ## Examples
 
-      iex> ExNylas.SmartCompose.create_stream(conn, message_id, prompt, IO.stream())
-      iex> data: {"suggestion": ""}
-      iex> data: {"suggestion": "Subject"}
-      ...
-      iex> data: {"suggestion": "]"}
-      iex> {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
+      iex> ExNylas.SmartCompose.create_reply_stream(conn, message_id, prompt, &IO.write/1)
+      iex> Dear [Recipient], ...
+      iex> {:ok, ""}
   """
   def create_reply_stream(%Conn{} = conn, message_id, prompt, stream_to) do
     Req.new(
@@ -93,7 +115,7 @@ defmodule ExNylas.SmartCompose do
       headers: API.base_headers([accept: "text/event-stream"]),
       json: %{prompt: prompt},
       decode_body: false,
-      into: stream_to,
+      into: API.handle_stream(stream_to),
       compressed: false
     )
     |> Req.post(conn.options)

--- a/lib/ex_nylas/smart_compose.ex
+++ b/lib/ex_nylas/smart_compose.ex
@@ -15,8 +15,9 @@ defmodule ExNylas.SmartCompose do
   @doc """
   Smart compose a message reply.
 
-  Example
-      {:ok, res} = ExNylas.SmartCompose.create_reply(conn, message_id, prompt)
+  ## Examples
+
+      iex> {:ok, res} = ExNylas.SmartCompose.create_reply(conn, message_id, prompt)
   """
   def create_reply(%Conn{} = conn, message_id, prompt) do
     Req.new(
@@ -33,8 +34,9 @@ defmodule ExNylas.SmartCompose do
   @doc """
   Smart compose a message reply.
 
-  Example
-      res = ExNylas.SmartCompose.create_reply!(conn, message_id, prompt)
+  ## Examples
+
+      iex> res = ExNylas.SmartCompose.create_reply!(conn, message_id, prompt)
   """
   def create_reply!(%Conn{} = conn, message_id, prompt) do
     case create_reply(conn, message_id, prompt) do
@@ -48,13 +50,14 @@ defmodule ExNylas.SmartCompose do
 
   Note - the response is a stream of untransformed events as shown in the example below.
 
-  Example
-      ExNylas.SmartCompose.create_stream(conn, prompt, IO.stream())
-      data: {"suggestion": ""}
-      data: {"suggestion": "Subject"}
+  ## Examples
+
+      iex> ExNylas.SmartCompose.create_stream(conn, prompt, IO.stream())
+      iex> data: {"suggestion": ""}
+      iex> data: {"suggestion": "Subject"}
       ...
-      data: {"suggestion": "]"}
-      {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
+      iex> data: {"suggestion": "]"}
+      iex> {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
   """
   def create_stream(%Conn{} = conn, prompt, stream_to) do
     Req.new(
@@ -74,13 +77,14 @@ defmodule ExNylas.SmartCompose do
 
   Note - the response is a stream of untransformed events as shown in the example below.
 
-  Example
-      ExNylas.SmartCompose.create_stream(conn, message_id, prompt, IO.stream())
-      data: {"suggestion": ""}
-      data: {"suggestion": "Subject"}
+  ## Examples
+
+      iex> ExNylas.SmartCompose.create_stream(conn, message_id, prompt, IO.stream())
+      iex> data: {"suggestion": ""}
+      iex> data: {"suggestion": "Subject"}
       ...
-      data: {"suggestion": "]"}
-      {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
+      iex> data: {"suggestion": "]"}
+      iex> {:ok, %IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line}}
   """
   def create_reply_stream(%Conn{} = conn, message_id, prompt, stream_to) do
     Req.new(

--- a/lib/ex_nylas/smart_compose.ex
+++ b/lib/ex_nylas/smart_compose.ex
@@ -22,7 +22,7 @@ defmodule ExNylas.SmartCompose do
     Req.new(
       url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/messages/#{message_id}/smart-compose",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json"]),
+      headers: API.base_headers(),
       json: %{prompt: prompt},
       decode_body: false
     )
@@ -60,7 +60,7 @@ defmodule ExNylas.SmartCompose do
     Req.new(
       url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/messages/smart-compose",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json", accept: "text/event-stream"]),
+      headers: API.base_headers([accept: "text/event-stream"]),
       json: %{prompt: prompt},
       into: stream_to,
       compressed: false
@@ -86,7 +86,7 @@ defmodule ExNylas.SmartCompose do
     Req.new(
       url: "#{conn.api_server}/v3/grants/#{conn.grant_id}/messages/#{message_id}/smart-compose",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json", accept: "text/event-stream"]),
+      headers: API.base_headers([accept: "text/event-stream"]),
       json: %{prompt: prompt},
       decode_body: false,
       into: stream_to,

--- a/lib/ex_nylas/util/api.ex
+++ b/lib/ex_nylas/util/api.ex
@@ -77,7 +77,6 @@ defmodule ExNylas.API do
   # Handle streaming response for Smart Compose endpoints
   def handle_stream(fun) do
     fn {:data, data}, {req, resp} ->
-
       case resp.status in 200..299 do
         true ->
           data

--- a/lib/ex_nylas/webhooks.ex
+++ b/lib/ex_nylas/webhooks.ex
@@ -16,8 +16,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Rotate a webhook secret.
 
-  Example
-      {:ok, webhook} = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
+  ## Examples
+
+      iex> {:ok, webhook} = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
   """
   def rotate_secret(%Conn{} = conn, webhook_id) do
     Req.new(
@@ -33,8 +34,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Rotate a webhook secret.
 
-  Example
-      webhook = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
+  ## Examples
+
+      iex> webhook = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
   """
   def rotate_secret!(%Conn{} = conn, webhook_id) do
     case rotate_secret(conn, webhook_id) do
@@ -46,8 +48,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Get a mock webhook payload.
 
-  Example
-      {:ok, payload} = ExNylas.Webhooks.mock_payload(conn, trigger)
+  ## Examples
+
+      iex> {:ok, payload} = ExNylas.Webhooks.mock_payload(conn, trigger)
   """
   def mock_payload(%Conn{} = conn, trigger) do
     Req.new(
@@ -64,8 +67,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Get a mock webhook payload.
 
-  Example
-      payload = ExNylas.Webhooks.mock_payload(conn, trigger)
+  ## Examples
+
+      iex> payload = ExNylas.Webhooks.mock_payload(conn, trigger)
   """
   def mock_payload!(%Conn{} = conn, trigger) do
     case mock_payload(conn, trigger) do
@@ -77,8 +81,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Send a test webhook event.
 
-  Example
-      {:ok, res} = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
+  ## Examples
+
+      iex> {:ok, res} = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
   """
   def send_test_event(%Conn{} = conn, trigger, callback_url) do
     Req.new(
@@ -95,8 +100,9 @@ defmodule ExNylas.Webhooks do
   @doc """
   Send a test webhook event.
 
-  Example
-      res = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
+  ## Examples
+
+      iex> res = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
   """
   def send_test_event!(%Conn{} = conn, trigger, callback_url) do
     case send_test_event(conn, trigger, callback_url) do

--- a/lib/ex_nylas/webhooks.ex
+++ b/lib/ex_nylas/webhooks.ex
@@ -53,7 +53,7 @@ defmodule ExNylas.Webhooks do
     Req.new(
       url: "#{conn.api_server}/v3/webhooks/mock-payload",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json"]),
+      headers: API.base_headers(),
       json: %{trigger_type: trigger},
       decode_body: false
     )
@@ -84,7 +84,7 @@ defmodule ExNylas.Webhooks do
     Req.new(
       url: "#{conn.api_server}/v3/webhooks/mock-payload",
       auth: API.auth_bearer(conn),
-      headers: API.base_headers(["content-type": "application/json"]),
+      headers: API.base_headers(),
       json: %{trigger_type: trigger, callback_url: callback_url},
       decode_body: false
     )

--- a/lib/ex_nylas/webhooks.ex
+++ b/lib/ex_nylas/webhooks.ex
@@ -17,7 +17,7 @@ defmodule ExNylas.Webhooks do
   Rotate a webhook secret.
 
   Example
-      {:ok, webhook} = ExNylas.Webhooks.rotate_secret(conn, `webhook_id`)
+      {:ok, webhook} = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
   """
   def rotate_secret(%Conn{} = conn, webhook_id) do
     Req.new(
@@ -34,7 +34,7 @@ defmodule ExNylas.Webhooks do
   Rotate a webhook secret.
 
   Example
-      webhook = ExNylas.Webhooks.rotate_secret(conn, `webhook_id`)
+      webhook = ExNylas.Webhooks.rotate_secret(conn, webhook_id)
   """
   def rotate_secret!(%Conn{} = conn, webhook_id) do
     case rotate_secret(conn, webhook_id) do
@@ -47,7 +47,7 @@ defmodule ExNylas.Webhooks do
   Get a mock webhook payload.
 
   Example
-      {:ok, payload} = ExNylas.Webhooks.mock_payload(conn, `trigger`)
+      {:ok, payload} = ExNylas.Webhooks.mock_payload(conn, trigger)
   """
   def mock_payload(%Conn{} = conn, trigger) do
     Req.new(
@@ -65,7 +65,7 @@ defmodule ExNylas.Webhooks do
   Get a mock webhook payload.
 
   Example
-      payload = ExNylas.Webhooks.mock_payload(conn, `trigger`)
+      payload = ExNylas.Webhooks.mock_payload(conn, trigger)
   """
   def mock_payload!(%Conn{} = conn, trigger) do
     case mock_payload(conn, trigger) do
@@ -78,7 +78,7 @@ defmodule ExNylas.Webhooks do
   Send a test webhook event.
 
   Example
-      {:ok, res} = ExNylas.Webhooks.send_test_event(conn, `trigger`, `callback_url`)
+      {:ok, res} = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
   """
   def send_test_event(%Conn{} = conn, trigger, callback_url) do
     Req.new(
@@ -96,7 +96,7 @@ defmodule ExNylas.Webhooks do
   Send a test webhook event.
 
   Example
-      res = ExNylas.Webhooks.send_test_event(conn, `trigger`, `callback_url`)
+      res = ExNylas.Webhooks.send_test_event(conn, trigger, callback_url)
   """
   def send_test_event!(%Conn{} = conn, trigger, callback_url) do
     case send_test_event(conn, trigger, callback_url) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
- Setting content type header when using the `json` option in Req is not needed ([ref](https://hexdocs.pm/req/Req.Steps.html#encode_body/1)).
- Docs cleanup
- Small fixes for generated create, generated update, contacts, drafts and free/busy
- Standardize smart compose streaming funcs args
- Transform chunks from smart compose stream