### PR TITLE
Paging/all enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ ExNylas.Folders.build(%{display_name: "Hello Error"})
 5. [Ecto](https://hex.pm/packages/ecto) is also used when transforming the API response from Nylas into structs.  Any validation errors are logged, but errors are not returned/raised in order to make to SDK resilient to changes to the API contract.
 
 6. Use `all/2` to fetch all of a given object and let the SDK page for you.  Req will handle retries on errors by default, if retries fail, partial results are not returned.  Note - depending on the result set, this operation could take time, consider using a query/filter to reduce the number of results and/or making this an async operation.
+
+Optionally include:
+- `delay` to throttle requests and avoid 429s
+- `send_to` to pass each page to your single arity function instead of accumulating all of the result set in memory
+
 ```elixir
 conn = %ExNylas.Connection{api_key: "1234", grant_id: "1234"}
-{:ok, all_messages} = ExNylas.Messages.all(conn, to: "hello@example.com")
+{:ok, all_messages} = ExNylas.Messages.all(conn, send_to: &IO.inspect/1, delay: 3_000, query: [any_email: "nick@example.com", fields: "include_headers"])
 
 # Or handle paging on your own
 {:ok, first_page} = ExNylas.Messages.list(conn, limit: 50)

--- a/lib/ex_nylas.ex
+++ b/lib/ex_nylas.ex
@@ -43,23 +43,33 @@ defmodule ExNylas do
       @doc """
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
-      ## Examples
+      The second argument can be a keyword list of options + query parameters to pass to the Nylas API (map is also supported).  Options supports:
+      - `:send_to` - a single arity function to send each page of results (default is nil, e.g. results will be accumulated and returned as a list)
+      - `:delay` - the number of milliseconds to wait between each page request (default is 0)
+      - `:query` - a keyword list or map of query parameters to pass to the Nylas API (default is an empty list)
 
-          iex> {:ok, result} = #{ExNylas.format_module_name(__MODULE__)}.all(conn, params)
+      ## Examples
+          iex> opts = [send_to: &IO.inspect/1, delay: 3_000, query: [key: "value"]]
+          iex> {:ok, result} = #{ExNylas.format_module_name(__MODULE__)}.all(conn, opts)
       """
-      def unquote(config.name)(%Conn{} = conn, params \\ []) do
-        ExNylas.Paging.all(conn, __MODULE__, unquote(use_cursor_paging), params)
+      def unquote(config.name)(%Conn{} = conn, opts \\ []) do
+        ExNylas.Paging.all(conn, __MODULE__, unquote(use_cursor_paging), opts)
       end
 
       @doc """
       Fetch all #{unquote(readable_name)}(s) matching the provided query (function will handle paging).
 
-      ## Examples
+      The second argument can be a keyword list of options + query parameters to pass to the Nylas API (map is also supported).  Options supports:
+      - `:send_to` - a single arity function to send each page of results (default is nil, e.g. results will be accumulated and returned as a list)
+      - `:delay` - the number of milliseconds to wait between each page request (default is 0)
+      - `:query` - a keyword list or map of query parameters to pass to the Nylas API (default is an empty list)
 
-          iex> result = #{ExNylas.format_module_name(__MODULE__)}.all!(conn, params)
+      ## Examples
+          iex> opts = [send_to: &IO.inspect/1, delay: 3_000, query: [key: "value"]]
+          iex> result = #{ExNylas.format_module_name(__MODULE__)}.all!(conn, opts)
       """
-      def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, params \\ []) do
-        case unquote(config.name)(conn, params) do
+      def unquote("#{config.name}!" |> String.to_atom())(%Conn{} = conn, opts \\ []) do
+        case unquote(config.name)(conn, opts) do
           {:ok, body} -> body
           {:error, reason} -> raise ExNylasError, reason
         end

--- a/lib/ex_nylas/util/paging.ex
+++ b/lib/ex_nylas/util/paging.ex
@@ -7,35 +7,50 @@ defmodule ExNylas.Paging do
 
   @limit 50
 
-  def all(conn, resource, use_cursor_paging, params \\ [])
-  def all(%Conn{} = conn, resource, true = _use_cursor_paging, params), do: page_with_cursor(conn, resource, params)
-  def all(%Conn{} = conn, resource, false = _use_cursor_paging, params), do: page_with_offset(conn, resource, params)
+  def all(conn, resource, use_cursor_paging, opts \\ [])
+  def all(%Conn{} = conn, resource, true = _use_cursor_paging, opts) do
+    {query, delay, send_to} = unwrap_opts(opts)
+    page_with_cursor(conn, resource, query, delay, send_to)
+  end
 
-  def all!(conn, resource, use_cursor_paging, params \\ [])
-  def all!(%Conn{} = conn, resource, true = _use_cursor_paging, params) do
-    case page_with_cursor(conn, resource, params) do
+  def all(%Conn{} = conn, resource, false = _use_cursor_paging, opts) do
+    {query, delay, send_to} = unwrap_opts(opts)
+    page_with_offset(conn, resource, query, delay, send_to)
+  end
+
+  def all!(conn, resource, use_cursor_paging, opts \\ [])
+  def all!(%Conn{} = conn, resource, true = _use_cursor_paging, opts) do
+    {query, delay, send_to} = unwrap_opts(opts)
+
+    case page_with_cursor(conn, resource, query, delay, send_to) do
       {:ok, res} -> res
       {:error, reason} -> raise ExNylasError, reason
     end
   end
 
-  def all!(%Conn{} = conn, resource, false = _use_cursor_paging, params) do
-    case page_with_offset(conn, resource, params) do
+  def all!(%Conn{} = conn, resource, false = _use_cursor_paging, opts) do
+    {query, delay, send_to} = unwrap_opts(opts)
+
+    case page_with_offset(conn, resource, query, delay, send_to) do
       {:ok, res} -> res
       {:error, reason} -> raise ExNylasError, reason
     end
   end
 
-  defp page_with_cursor(%Conn{} = conn, resource, query, next_cursor \\ nil, acc \\ []) do
+  defp page_with_cursor(%Conn{} = conn, resource, query, delay, send_to, next_cursor \\ nil, acc \\ []) do
     query = put_in(query, [:page_token], next_cursor)
 
     case apply(resource, :list, [conn, query]) do
       {:ok, res} ->
-        new = acc ++ Map.get(res, :data, [])
+        new = send_or_accumulate(send_to, acc, Map.get(res, :data, []))
 
         case res.next_cursor do
-          nil -> {:ok, new}
-          _ -> page_with_cursor(conn, resource, query, res.next_cursor, new)
+          nil ->
+            {:ok, new}
+
+          _ ->
+            maybe_delay(delay)
+            page_with_cursor(conn, resource, query, delay, send_to, res.next_cursor, new)
         end
 
       err ->
@@ -43,7 +58,7 @@ defmodule ExNylas.Paging do
     end
   end
 
-  defp page_with_offset(%Conn{} = conn, resource, query, offset \\ 0, acc \\ []) do
+  defp page_with_offset(%Conn{} = conn, resource, query, delay, send_to, offset \\ 0, acc \\ []) do
     query =
       query
       |> indifferent_put_new(:limit, @limit)
@@ -52,12 +67,16 @@ defmodule ExNylas.Paging do
     case apply(resource, :list, [conn, query]) do
       {:ok, res} ->
         data = Map.get(res, :data, [])
-        new = acc ++ data
+        new = send_or_accumulate(send_to, acc, data)
         limit = Map.get(query, :limit)
 
         case length(data) == limit do
-          true -> page_with_offset(conn, resource, query, offset + limit, new)
-          false -> {:ok, new}
+          true ->
+            maybe_delay(delay)
+            page_with_offset(conn, resource, query, delay, send_to, offset + limit, new)
+
+          false ->
+            {:ok, new}
         end
 
       err ->
@@ -71,5 +90,30 @@ defmodule ExNylas.Paging do
 
   defp indifferent_put_new(keyword, key, value) when is_list(keyword) do
     Keyword.put_new(keyword, key, value)
+  end
+
+  defp indifferent_get(map, key, default) when is_map(map) do
+    Map.get(map, key, default)
+  end
+
+  defp indifferent_get(keyword, key, default) when is_list(keyword) do
+    Keyword.get(keyword, key, default)
+  end
+
+  defp unwrap_opts(opts) do
+    {
+      indifferent_get(opts, :query, []),
+      indifferent_get(opts, :delay, 0),
+      indifferent_get(opts, :send_to, nil)
+    }
+  end
+
+  defp maybe_delay(delay) when delay <= 0, do: :ok
+  defp maybe_delay(delay) when delay > 0, do: :timer.sleep(delay)
+
+  defp send_or_accumulate(nil, acc, data), do: acc ++ data
+  defp send_or_accumulate(send_to, acc, data) do
+    send_to.(data)
+    acc
   end
 end


### PR DESCRIPTION
When calling `.all/2`, optionally provide a delay and/or a function to send each page to instead of waiting for all of the results.