### PR TITLE
Remove validate_required, update schemas for select query param

### DIFF
--- a/lib/ex_nylas/application/schema.ex
+++ b/lib/ex_nylas/application/schema.ex
@@ -14,12 +14,12 @@ defmodule ExNylas.Application do
   @primary_key false
 
   typed_embedded_schema do
-    field(:application_id, :string, null: false)
-    field(:created_at, :integer, null: false) :: non_neg_integer()
-    field(:environment, Ecto.Enum, values: ~w(production staging development sandbox)a, null: false)
-    field(:organization_id, :string, null: false)
-    field(:region, Ecto.Enum, values: ~w(us eu)a, null: false)
-    field(:updated_at, :integer, null: false) :: non_neg_integer()
+    field(:application_id, :string)
+    field(:created_at, :integer) :: non_neg_integer() | nil
+    field(:environment, Ecto.Enum, values: ~w(production staging development sandbox)a)
+    field(:organization_id, :string)
+    field(:region, Ecto.Enum, values: ~w(us eu)a)
+    field(:updated_at, :integer) :: non_neg_integer() | nil
     field(:v2_application_id, :string)
 
     embeds_one :branding, Branding, primary_key: false do
@@ -50,6 +50,5 @@ defmodule ExNylas.Application do
     |> cast_embed(:branding, with: &Util.embedded_changeset/2)
     |> cast_embed(:hosted_authentication, with: &Util.embedded_changeset/2)
     |> cast_embed(:callback_uris)
-    |> validate_required([:application_id, :organization_id, :region, :created_at, :updated_at, :environment])
   end
 end

--- a/lib/ex_nylas/application_redirects/schema.ex
+++ b/lib/ex_nylas/application_redirects/schema.ex
@@ -9,15 +9,14 @@ defmodule ExNylas.ApplicationRedirect do
   @primary_key false
 
   typed_embedded_schema do
-    field(:id, :string, null: false)
-    field(:platform, Ecto.Enum, values: ~w(web desktop js ios android)a, null: false)
-    field(:url, :string, null: false)
+    field(:id, :string)
+    field(:platform, Ecto.Enum, values: ~w(web desktop js ios android)a)
+    field(:url, :string)
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:url, :id])
   end
 end

--- a/lib/ex_nylas/attachments/schema.ex
+++ b/lib/ex_nylas/attachments/schema.ex
@@ -11,18 +11,17 @@ defmodule ExNylas.Attachment do
   typed_embedded_schema do
     field(:content_disposition, :string)
     field(:content_id, :string)
-    field(:content_type, :string, null: false)
-    field(:filename, :string, null: false)
-    field(:grant_id, :string, null: false)
-    field(:id, :string, null: false)
-    field(:is_inline, :boolean, null: false)
-    field(:size, :integer, null: false) :: non_neg_integer()
+    field(:content_type, :string)
+    field(:filename, :string)
+    field(:grant_id, :string)
+    field(:id, :string)
+    field(:is_inline, :boolean)
+    field(:size, :integer) :: non_neg_integer() | nil
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/calendars/schema.ex
+++ b/lib/ex_nylas/calendars/schema.ex
@@ -10,17 +10,17 @@ defmodule ExNylas.Calendar do
 
   typed_embedded_schema do
     field(:description, :string)
-    field(:grant_id, :string, null: false)
+    field(:grant_id, :string)
     field(:hex_color, :string)
     field(:hex_foreground_color, :string)
-    field(:id, :string, null: false)
-    field(:is_owned_by_user, :boolean, null: false)
-    field(:is_primary, :boolean, null: false)
+    field(:id, :string)
+    field(:is_owned_by_user, :boolean)
+    field(:is_primary, :boolean)
     field(:location, :string)
     field(:metadata, :map)
-    field(:name, :string, null: false)
-    field(:object, :string, null: false)
-    field(:read_only, :boolean, null: false)
+    field(:name, :string)
+    field(:object, :string)
+    field(:read_only, :boolean)
     field(:timezone, :string)
   end
 
@@ -28,6 +28,5 @@ defmodule ExNylas.Calendar do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/channels/schema.ex
+++ b/lib/ex_nylas/channels/schema.ex
@@ -10,11 +10,11 @@ defmodule ExNylas.Channel do
 
   typed_embedded_schema do
     field(:description, :string)
-    field(:id, :string, null: false)
-    field(:notification_email_addresses, {:array, :string}, null: false)
-    field(:status, Ecto.Enum, values: ~w(active pause failing failed)a, null: false)
+    field(:id, :string)
+    field(:notification_email_addresses, {:array, :string})
+    field(:status, Ecto.Enum, values: ~w(active pause failing failed)a)
     field(:topic, :string)
-    field(:trigger_types, {:array, :string}, null: false)
+    field(:trigger_types, {:array, :string})
     field(:created_at, :integer)
     field(:updated_at, :integer)
     field(:status_updated_at, :integer)
@@ -24,6 +24,5 @@ defmodule ExNylas.Channel do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :trigger_types, :webhook_url, :status, :created_at, :updated_at, :status_updated_at])
   end
 end

--- a/lib/ex_nylas/common/availability.ex
+++ b/lib/ex_nylas/common/availability.ex
@@ -11,12 +11,12 @@ defmodule ExNylas.Common.Availability do
   @primary_key false
 
   typed_embedded_schema do
-    field(:order, {:array, :string}, null: false)
+    field(:order, {:array, :string})
 
     embeds_many :time_slots, TimeSlot, primary_key: false do
       field(:emails, {:array, :string})
-      field(:end_time, :integer) :: non_neg_integer()
-      field(:start_time, :integer) :: non_neg_integer()
+      field(:end_time, :integer) :: non_neg_integer() | nil
+      field(:start_time, :integer) :: non_neg_integer() | nil
     end
   end
 

--- a/lib/ex_nylas/common/availability_rules.ex
+++ b/lib/ex_nylas/common/availability_rules.ex
@@ -13,7 +13,7 @@ defmodule ExNylas.Common.AvailabilityRules do
   @primary_key false
 
   typed_embedded_schema do
-    field(:availability_method, Ecto.Enum, values: ~w(collective max-fairness max-availability)a, null: false)
+    field(:availability_method, Ecto.Enum, values: ~w(collective max-fairness max-availability)a)
     field(:round_robin_group_id, :string)
 
     embeds_one :buffer, Buffer

--- a/lib/ex_nylas/common/email_participant.ex
+++ b/lib/ex_nylas/common/email_participant.ex
@@ -9,7 +9,7 @@ defmodule ExNylas.Common.EmailParticipant do
   @primary_key false
 
   typed_embedded_schema do
-    field(:email, :string, null: false)
+    field(:email, :string)
     field(:name, :string)
   end
 
@@ -17,6 +17,5 @@ defmodule ExNylas.Common.EmailParticipant do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:email])
   end
 end

--- a/lib/ex_nylas/common/error.ex
+++ b/lib/ex_nylas/common/error.ex
@@ -9,7 +9,7 @@ defmodule ExNylas.Common.Error do
   @primary_key false
 
   typed_embedded_schema do
-    field(:message, :string, null: false)
+    field(:message, :string)
     field(:provider_error, :map)
     field(:type, :string)
   end

--- a/lib/ex_nylas/common/event_booking.ex
+++ b/lib/ex_nylas/common/event_booking.ex
@@ -14,12 +14,12 @@ defmodule ExNylas.Common.EventBooking do
 
   typed_embedded_schema do
     field(:additional_fields, :map)
-    field(:booking_type, Ecto.Enum, values: ~w(booking)a, null: false)
+    field(:booking_type, Ecto.Enum, values: ~w(booking)a)
     field(:description, :string)
-    field(:disable_emails, :boolean, null: false)
-    field(:hide_participants, :boolean, null: false)
+    field(:disable_emails, :boolean)
+    field(:hide_participants, :boolean)
     field(:location, :string)
-    field(:title, :string, null: false)
+    field(:title, :string)
     field(:timezone, :string)
 
     embeds_one :conferencing, EventConferencing
@@ -32,6 +32,5 @@ defmodule ExNylas.Common.EventBooking do
     |> cast(params, [:title, :location, :description, :booking_type, :additional_fields, :hide_participants, :disable_emails, :timezone])
     |> cast_embed(:conferencing)
     |> cast_embed(:reminders)
-    |> validate_required([:title])
   end
 end

--- a/lib/ex_nylas/common/event_reminder.ex
+++ b/lib/ex_nylas/common/event_reminder.ex
@@ -10,7 +10,7 @@ defmodule ExNylas.Common.EventReminder do
 
   typed_embedded_schema do
     field(:overrides, {:array, :map})
-    field(:use_default, :boolean, null: false)
+    field(:use_default, :boolean)
   end
 
   @doc false

--- a/lib/ex_nylas/common/message_header.ex
+++ b/lib/ex_nylas/common/message_header.ex
@@ -9,8 +9,8 @@ defmodule ExNylas.Common.MessageHeader do
   @primary_key false
 
   typed_embedded_schema do
-    field(:name, :string, null: false)
-    field(:value, :string, null: false)
+    field(:name, :string)
+    field(:value, :string)
   end
 
   @doc false

--- a/lib/ex_nylas/common/response.ex
+++ b/lib/ex_nylas/common/response.ex
@@ -17,8 +17,8 @@ defmodule ExNylas.Common.Response do
   typed_embedded_schema do
     field(:data, MapOrList)
     field(:next_cursor, :string)
-    field(:request_id, :string, null: false)
-    field(:status, Atom, null: false)
+    field(:request_id, :string)
+    field(:status, Atom)
 
     embeds_one :error, Error
   end

--- a/lib/ex_nylas/connector_credentials/schema.ex
+++ b/lib/ex_nylas/connector_credentials/schema.ex
@@ -9,18 +9,17 @@ defmodule ExNylas.ConnectorCredential do
   @primary_key false
 
   typed_embedded_schema do
-    field(:created_at, :integer) :: non_neg_integer()
-    field(:credential_type, Ecto.Enum, values: ~w(adminconsent serviceaccount)a, null: false)
+    field(:created_at, :integer) :: non_neg_integer() | nil
+    field(:credential_type, Ecto.Enum, values: ~w(adminconsent serviceaccount)a)
     field(:hashed_data, :string)
-    field(:id, :string, null: false)
-    field(:name, :string, null: false)
-    field(:updated_at, :integer) :: non_neg_integer()
+    field(:id, :string)
+    field(:name, :string)
+    field(:updated_at, :integer) :: non_neg_integer() | nil
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id])
   end
 end

--- a/lib/ex_nylas/connectors/schema.ex
+++ b/lib/ex_nylas/connectors/schema.ex
@@ -10,7 +10,7 @@ defmodule ExNylas.Connector do
   @primary_key false
 
   typed_embedded_schema do
-    field(:provider, Ecto.Enum, values: ~w(google microsoft imap virtual-calendar icloud yahoo zoom ews)a, null: false)
+    field(:provider, Ecto.Enum, values: ~w(google microsoft imap virtual-calendar icloud yahoo zoom ews)a)
     field(:scope, {:array, :string})
 
     embeds_one :settings, Settings, primary_key: false do
@@ -26,6 +26,5 @@ defmodule ExNylas.Connector do
     struct
     |> cast(params, [:provider, :scope])
     |> cast_embed(:settings, with: &embedded_changeset/2)
-    |> validate_required([:provider])
   end
 end

--- a/lib/ex_nylas/contact_groups/schema.ex
+++ b/lib/ex_nylas/contact_groups/schema.ex
@@ -9,11 +9,11 @@ defmodule ExNylas.ContactGroup do
   @primary_key false
 
   typed_embedded_schema do
-    field(:grant_id, :string, null: false)
-    field(:group_type, Ecto.Enum, values: ~w(system user other)a, null: false)
-    field(:id, :string, null: false)
+    field(:grant_id, :string)
+    field(:group_type, Ecto.Enum, values: ~w(system user other)a)
+    field(:id, :string)
     field(:name, :string)
-    field(:object, :string, null: false)
+    field(:object, :string)
     field(:path, :string)
   end
 
@@ -21,6 +21,5 @@ defmodule ExNylas.ContactGroup do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/contacts/schema.ex
+++ b/lib/ex_nylas/contacts/schema.ex
@@ -14,32 +14,32 @@ defmodule ExNylas.Contact do
     field(:birthday, :string)
     field(:company_name, :string)
     field(:given_name, :string)
-    field(:grant_id, :string, null: false)
-    field(:id, :string, null: false)
+    field(:grant_id, :string)
+    field(:id, :string)
     field(:job_title, :string)
     field(:manager_name, :string)
     field(:notes, :string)
-    field(:object, :string, null: false)
+    field(:object, :string)
     field(:office_location, :string)
-    field(:source, Ecto.Enum, values: ~w(address_book domain inbox)a, null: false)
+    field(:source, Ecto.Enum, values: ~w(address_book domain inbox)a)
 
     embeds_many :emails, Email, primary_key: false do
-      field(:email, :string, null: false)
+      field(:email, :string)
       field(:type, :string)
     end
 
     embeds_many :groups, ContactGroup, primary_key: false do
-      field(:id, :string, null: false)
+      field(:id, :string)
       field(:name, :string)
     end
 
     embeds_many :im_addresses, ImAddress, primary_key: false do
-      field(:im_address, :string, null: false)
+      field(:im_address, :string)
       field(:type, :string)
     end
 
     embeds_many :phone_numbers, PhoneNumber, primary_key: false do
-      field(:number, :string, null: false)
+      field(:number, :string)
       field(:type, Ecto.Enum, values: ~w(work home other)a)
     end
 
@@ -54,7 +54,7 @@ defmodule ExNylas.Contact do
     end
 
     embeds_many :web_pages, WebPage, primary_key: false do
-      field(:url, :string, null: false)
+      field(:url, :string)
       field(:type, Ecto.Enum, values: ~w(work home other)a)
     end
   end
@@ -69,6 +69,5 @@ defmodule ExNylas.Contact do
     |> cast_embed(:phone_numbers, with: &Util.embedded_changeset/2)
     |> cast_embed(:physical_addresses, with: &Util.embedded_changeset/2)
     |> cast_embed(:web_pages, with: &Util.embedded_changeset/2)
-    |> validate_required([:grant_id, :id])
   end
 end

--- a/lib/ex_nylas/drafts/schema.ex
+++ b/lib/ex_nylas/drafts/schema.ex
@@ -16,11 +16,11 @@ defmodule ExNylas.Draft do
 
   typed_embedded_schema do
     field(:body, :string)
-    field(:date, :integer) :: non_neg_integer()
-    field(:folders, {:array, :string}, null: false)
-    field(:grant_id, :string, null: false)
-    field(:id, :string, null: false)
-    field(:object, :string, null: false)
+    field(:date, :integer) :: non_neg_integer() | nil
+    field(:folders, {:array, :string})
+    field(:grant_id, :string)
+    field(:id, :string)
+    field(:object, :string)
     field(:reply_to_message_id, :string)
     field(:snippet, :string)
     field(:starred, :boolean)
@@ -47,6 +47,5 @@ defmodule ExNylas.Draft do
     |> cast_embed(:bcc)
     |> cast_embed(:tracking_options)
     |> cast_embed(:reply_to)
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/events/schema.ex
+++ b/lib/ex_nylas/events/schema.ex
@@ -11,20 +11,20 @@ defmodule ExNylas.Event do
   @primary_key false
 
   typed_embedded_schema do
-    field(:busy, :boolean, null: false)
-    field(:calendar_id, :string, null: false)
+    field(:busy, :boolean)
+    field(:calendar_id, :string)
     field(:capacity, :integer)
     field(:created_at, :integer)
     field(:description, :string)
     field(:hide_participants, :boolean)
-    field(:grant_id, :string, null: false)
+    field(:grant_id, :string)
     field(:html_link, :string)
     field(:ical_uid, :string)
-    field(:id, :string, null: false)
+    field(:id, :string)
     field(:location, :string)
     field(:master_event_id, :string)
     field(:metadata, :map)
-    field(:object, :string, null: false)
+    field(:object, :string)
     field(:read_only, :boolean)
     field(:recurrence, {:array, :string})
     field(:status, Ecto.Enum, values: ~w(confirmed canceled maybe)a)
@@ -41,21 +41,21 @@ defmodule ExNylas.Event do
     end
 
     embeds_one :organizer, Organizer, primary_key: false do
-      field(:email, :string, null: false)
+      field(:email, :string)
       field(:name, :string)
     end
 
     embeds_many :participants, Participant, primary_key: false do
       field(:comment, :string)
-      field(:email, :string, null: false)
+      field(:email, :string)
       field(:name, :string)
       field(:phone_number, :string)
-      field(:status, Ecto.Enum, values: ~w(yes no maybe noreply)a, null: false)
+      field(:status, Ecto.Enum, values: ~w(yes no maybe noreply)a)
     end
 
     embeds_one :reminders, Reminder, primary_key: false do
       field(:overrides, {:array, :map})
-      field(:use_default, :boolean, null: false)
+      field(:use_default, :boolean)
     end
 
     embeds_one :when, When, primary_key: false do
@@ -63,7 +63,7 @@ defmodule ExNylas.Event do
       field(:end_date, :string)
       field(:end_time, :integer) :: non_neg_integer() | nil
       field(:end_timezone, :string)
-      field(:object, Ecto.Enum, values: ~w(time timespan date datespan)a, null: false)
+      field(:object, Ecto.Enum, values: ~w(time timespan date datespan)a)
       field(:start_date, :string)
       field(:start_time, :integer) :: non_neg_integer() | nil
       field(:start_timezone, :string)
@@ -81,6 +81,5 @@ defmodule ExNylas.Event do
     |> cast_embed(:conferencing, with: &Util.embedded_changeset/2)
     |> cast_embed(:reminders, with: &Util.embedded_changeset/2)
     |> cast_embed(:organizer, with: &Util.embedded_changeset/2)
-    |> validate_required([:id, :grant_id, :calendar_id])
   end
 end

--- a/lib/ex_nylas/folders/schema.ex
+++ b/lib/ex_nylas/folders/schema.ex
@@ -12,10 +12,10 @@ defmodule ExNylas.Folder do
     field(:attributes, {:array, :string})
     field(:background_color, :string)
     field(:child_count, :integer) :: non_neg_integer() | nil
-    field(:grant_id, :string, null: false)
-    field(:id, :string, null: false)
-    field(:name, :string, null: false)
-    field(:object, :string, null: false)
+    field(:grant_id, :string)
+    field(:id, :string)
+    field(:name, :string)
+    field(:object, :string)
     field(:parent_id, :string)
     field(:system_folder, :boolean)
     field(:text_color, :string)
@@ -27,6 +27,5 @@ defmodule ExNylas.Folder do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/free_busy/schema.ex
+++ b/lib/ex_nylas/free_busy/schema.ex
@@ -11,14 +11,14 @@ defmodule ExNylas.FreeBusy do
   @primary_key false
 
   typed_embedded_schema do
-    field(:email, :string, null: false)
-    field(:object, :string, null: false)
+    field(:email, :string)
+    field(:object, :string)
 
     embeds_many :time_slots, TimeSlot, primary_key: false do
-      field(:end_time, :integer, null: false) :: non_neg_integer()
-      field(:object, :string, null: false)
-      field(:start_time, :integer, null: false) :: non_neg_integer()
-      field(:status, :string, null: false)
+      field(:end_time, :integer) :: non_neg_integer() | nil
+      field(:object, :string)
+      field(:start_time, :integer) :: non_neg_integer() | nil
+      field(:status, :string)
     end
   end
 

--- a/lib/ex_nylas/grants/schema.ex
+++ b/lib/ex_nylas/grants/schema.ex
@@ -10,17 +10,17 @@ defmodule ExNylas.Grant do
 
   typed_embedded_schema do
     field(:account_id, :string)
-    field(:created_at, :integer, null: false) :: non_neg_integer()
-    field(:email, :string, null: false)
-    field(:grant_status, Ecto.Enum, values: ~w(valid invalid)a, null: false)
-    field(:id, :string, null: false)
+    field(:created_at, :integer) :: non_neg_integer() | nil
+    field(:email, :string)
+    field(:grant_status, Ecto.Enum, values: ~w(valid invalid)a)
+    field(:id, :string)
     field(:ip, :string)
-    field(:provider, Ecto.Enum, values: ~w(google microsoft imap virtual-calendar icloud yahoo zoom ews)a, null: false)
+    field(:provider, Ecto.Enum, values: ~w(google microsoft imap virtual-calendar icloud yahoo zoom ews)a)
     field(:provider_user_id, :string)
     field(:scope, {:array, :string})
     field(:settings, :map)
     field(:state, :string)
-    field(:updated_at, :integer, null: false) :: non_neg_integer()
+    field(:updated_at, :integer) :: non_neg_integer() | nil
     field(:user_agent, :string)
   end
 
@@ -28,6 +28,5 @@ defmodule ExNylas.Grant do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :provider, :grant_status])
   end
 end

--- a/lib/ex_nylas/hosted_authentication/schema.ex
+++ b/lib/ex_nylas/hosted_authentication/schema.ex
@@ -10,11 +10,11 @@ defmodule ExNylas.HostedAuthentication.Grant do
 
   typed_embedded_schema do
     field(:access_token, :string)
-    field(:email, :string, null: false)
-    field(:expires_in, :integer) :: non_neg_integer()
-    field(:grant_id, :string, null: false)
+    field(:email, :string)
+    field(:expires_in, :integer) :: non_neg_integer() | nil
+    field(:grant_id, :string)
     field(:id_token, :string)
-    field(:provider, Ecto.Enum, values: ~w(google microsoft icloud yahoo imap virtual-calendar zoom ews)a, null: false)
+    field(:provider, Ecto.Enum, values: ~w(google microsoft icloud yahoo imap virtual-calendar zoom ews)a)
     field(:refresh_token, :string)
     field(:scope, :string)
     field(:token_type, :string)
@@ -24,6 +24,5 @@ defmodule ExNylas.HostedAuthentication.Grant do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:access_token, :expires_in, :id_token, :refresh_token, :scope, :token_type, :grant_id, :provider, :email])
-    |> validate_required([:grant_id, :provider, :email])
   end
 end

--- a/lib/ex_nylas/message_schedules/schema.ex
+++ b/lib/ex_nylas/message_schedules/schema.ex
@@ -12,7 +12,7 @@ defmodule ExNylas.MessageSchedule do
 
   typed_embedded_schema do
     field(:close_time, :integer) :: non_neg_integer() | nil
-    field(:schedule_id, :string, null: false)
+    field(:schedule_id, :string)
 
     embeds_one :status, Status, primary_key: false do
       field(:code, :string)
@@ -25,6 +25,5 @@ defmodule ExNylas.MessageSchedule do
     struct
     |> cast(params, [:schedule_id, :close_time])
     |> cast_embed(:status, with: &Util.embedded_changeset/2)
-    |> validate_required([:schedule_id])
   end
 end

--- a/lib/ex_nylas/messages/schema.ex
+++ b/lib/ex_nylas/messages/schema.ex
@@ -17,12 +17,12 @@ defmodule ExNylas.Message do
   typed_embedded_schema do
     field(:body, :string)
     field(:conversation, :string)
-    field(:date, :integer) :: non_neg_integer()
-    field(:folders, {:array, :string}, null: false)
-    field(:grant_id, :string, null: false)
-    field(:id, :string, null: false)
+    field(:date, :integer) :: non_neg_integer() | nil
+    field(:folders, {:array, :string})
+    field(:grant_id, :string)
+    field(:id, :string)
     field(:metadata, :map)
-    field(:object, :string, null: false)
+    field(:object, :string)
     field(:schedule_id, :string)
     field(:snippet, :string)
     field(:starred, :boolean)
@@ -50,6 +50,5 @@ defmodule ExNylas.Message do
     |> cast_embed(:reply_to)
     |> cast_embed(:to)
     |> cast_embed(:headers)
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/providers/schema.ex
+++ b/lib/ex_nylas/providers/schema.ex
@@ -10,7 +10,7 @@ defmodule ExNylas.Provider do
 
   typed_embedded_schema do
     field(:email_address, :string)
-    field(:detected, :boolean, null: false)
+    field(:detected, :boolean)
     field(:provider, :string)
     field(:type, :string)
   end

--- a/lib/ex_nylas/room_resources/schema.ex
+++ b/lib/ex_nylas/room_resources/schema.ex
@@ -15,8 +15,8 @@ defmodule ExNylas.RoomResource do
     field(:floor_name, :string)
     field(:floor_number, :integer)
     field(:floor_section, :string)
-    field(:grant_id, :string, null: false)
-    field(:object, :string, null: false)
+    field(:grant_id, :string)
+    field(:object, :string)
   end
 
   @doc false

--- a/lib/ex_nylas/scheduling/bookings/schema.ex
+++ b/lib/ex_nylas/scheduling/bookings/schema.ex
@@ -9,13 +9,12 @@ defmodule ExNylas.Scheduling.Booking do
   @primary_key false
 
   typed_embedded_schema do
-    field(:booking_id, :string, null: false)
+    field(:booking_id, :string)
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:booking_id])
-    |> validate_required([:booking_id])
   end
 end

--- a/lib/ex_nylas/scheduling/configurations/schema.ex
+++ b/lib/ex_nylas/scheduling/configurations/schema.ex
@@ -16,27 +16,27 @@ defmodule ExNylas.Scheduling.Configuration do
   @primary_key false
 
   typed_embedded_schema do
-    field(:id, :string, null: false)
-    field(:requires_session_auth, :boolean, null: false)
+    field(:id, :string)
+    field(:requires_session_auth, :boolean)
 
     embeds_one :availability, Availability, primary_key: false do
-      field(:duration_minutes, :integer) :: non_neg_integer()
-      field(:interval_minutes, :integer) :: non_neg_integer()
-      field(:round_to, :integer) :: non_neg_integer()
+      field(:duration_minutes, :integer) :: non_neg_integer() | nil
+      field(:interval_minutes, :integer) :: non_neg_integer() | nil
+      field(:round_to, :integer) :: non_neg_integer() | nil
 
       embeds_one :availability_rules, AvailabilityRules
     end
 
     embeds_one :scheduler, Scheduler, primary_key: false do
       field(:additional_fields, :map)
-      field(:available_days_in_future, :integer) :: non_neg_integer()
+      field(:available_days_in_future, :integer) :: non_neg_integer() | nil
       field(:cancellation_policy, :string)
       field(:cancellation_url, :string)
       field(:hide_additionl_fields, :boolean)
       field(:hide_cancelation_options, :boolean)
       field(:hide_rescheduling_options, :boolean)
-      field(:min_booking_notice, :integer) :: non_neg_integer()
-      field(:min_cancellation_notice, :integer) :: non_neg_integer()
+      field(:min_booking_notice, :integer) :: non_neg_integer() | nil
+      field(:min_cancellation_notice, :integer) :: non_neg_integer() | nil
       field(:rescheduling_url, :string)
     end
 

--- a/lib/ex_nylas/scheduling/sessions/schema.ex
+++ b/lib/ex_nylas/scheduling/sessions/schema.ex
@@ -9,13 +9,12 @@ defmodule ExNylas.Scheduling.Session do
   @primary_key false
 
   typed_embedded_schema do
-    field(:session_id, :string, null: false)
+    field(:session_id, :string)
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:session_id])
-    |> validate_required([:session_id])
   end
 end

--- a/lib/ex_nylas/smart_compose/schema.ex
+++ b/lib/ex_nylas/smart_compose/schema.ex
@@ -9,13 +9,12 @@ defmodule ExNylas.Schema.SmartCompose do
   @primary_key false
 
   typed_embedded_schema do
-    field(:suggestion, :string, null: false)
+    field(:suggestion, :string)
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:suggestion])
   end
 end

--- a/lib/ex_nylas/threads/schema.ex
+++ b/lib/ex_nylas/threads/schema.ex
@@ -69,6 +69,5 @@ defmodule ExNylas.Thread do
     |> cast(params, [:grant_id, :id, :object, :has_attachments, :has_drafts, :earliest_message_timestamp, :last_message_received_at, :last_message_sent_at, :snippet, :starred, :subject, :unread, :message_ids, :draft_ids])
     |> cast_polymorphic_embed(:latest_draft_or_message, required: true)
     |> cast_embed(:participants)
-    |> validate_required([:id, :grant_id])
   end
 end

--- a/lib/ex_nylas/webhook_ips/schema.ex
+++ b/lib/ex_nylas/webhook_ips/schema.ex
@@ -9,14 +9,13 @@ defmodule ExNylas.WebhookIP do
   @primary_key false
 
   typed_embedded_schema do
-    field(:ip_addresses, {:array, :string}, null: false)
-    field(:updated_at, :integer, null: false) :: non_neg_integer()
+    field(:ip_addresses, {:array, :string})
+    field(:updated_at, :integer) :: non_neg_integer() | nil
   end
 
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:ip_addresses])
   end
 end

--- a/lib/ex_nylas/webhooks/schema.ex
+++ b/lib/ex_nylas/webhooks/schema.ex
@@ -10,11 +10,11 @@ defmodule ExNylas.Webhook do
 
   typed_embedded_schema do
     field(:description, :string)
-    field(:id, :string, null: false)
-    field(:notification_email_addresses, {:array, :string}, null: false)
-    field(:status, Ecto.Enum, values: ~w(active pause failing failed)a, null: false)
-    field(:trigger_types, {:array, :string}, null: false)
-    field(:webhook_url, :string, null: false)
+    field(:id, :string)
+    field(:notification_email_addresses, {:array, :string})
+    field(:status, Ecto.Enum, values: ~w(active pause failing failed)a)
+    field(:trigger_types, {:array, :string})
+    field(:webhook_url, :string)
     field(:webhook_secret, :string)
   end
 
@@ -22,6 +22,5 @@ defmodule ExNylas.Webhook do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, __MODULE__.__schema__(:fields))
-    |> validate_required([:id, :trigger_types, :webhook_url, :status])
   end
 end


### PR DESCRIPTION
Most Nylas endpoints now support passing the `select` query param to specify which fields should be returned in the response.  This means that any field is technically nullable in responses.  Updating schemas accordingly.