### PR TITLE
Convert truncated/transformed webhook triggers to the parent trigger type

### DIFF
--- a/lib/ex_nylas/util/webhook_notifications/webhook_notification_data.ex
+++ b/lib/ex_nylas/util/webhook_notifications/webhook_notification_data.ex
@@ -63,8 +63,6 @@ defmodule ExNylas.WebhookNotificationData do
 
         "message.created": Message,
         "message.updated": Message,
-        "message.created.truncated": Message,
-        "message.updated.truncated": Message,
         "message.send_success": Message,
         "message.send_failed": Message,
         "message.bounce_detected": MessageBounceDetected,
@@ -89,6 +87,10 @@ defmodule ExNylas.WebhookNotificationData do
   # Webhook trigger/type is the most reliable way to determine what notification.data.object should be transformed into.
   # Pass the trigger/type as params so it can be used by polymorphic_embeds_one.
   defp put_trigger(%{"trigger" => trigger, "object" => object} = params) do
-    %{params | "object" => Map.put(object, "trigger", trigger)}
+    %{params | "object" => Map.put(object, "trigger", to_parent_trigger(trigger))}
+  end
+
+  defp to_parent_trigger(trigger) when is_binary(trigger) do
+    String.replace(trigger, ~r/\.(truncated|transformed)$/, "")
   end
 end

--- a/test/util_test/webhook_notifications_test.exs
+++ b/test/util_test/webhook_notifications_test.exs
@@ -53,6 +53,24 @@ defmodule ExNylasTest.WebhookNotifications do
     assert res.data.object.__struct__ == ExNylas.Message
   end
 
+  test "to_struct transforms message.created.truncated into the correct parent type" do
+    {:ok, res} =
+      good_webhook_type()
+      |> Map.put("type", "message.created.truncated")
+      |> ExNylas.WebhookNotifications.to_struct()
+
+    assert res.data.object.__struct__ == ExNylas.Message
+  end
+
+  test "to_struct transforms message.created.transformed into the correct parent type" do
+    {:ok, res} =
+      good_webhook_type()
+      |> Map.put("type", "message.created.transformed")
+      |> ExNylas.WebhookNotifications.to_struct()
+
+    assert res.data.object.__struct__ == ExNylas.Message
+  end
+
   test "to_struct! transforms a raw webhook notification into an ExNylas struct" do
     res = ExNylas.WebhookNotifications.to_struct!(good_webhook_type())
     assert res.__struct__ == ExNylas.WebhookNotification

--- a/test/util_test/webhook_notifications_test.exs
+++ b/test/util_test/webhook_notifications_test.exs
@@ -71,6 +71,15 @@ defmodule ExNylasTest.WebhookNotifications do
     assert res.data.object.__struct__ == ExNylas.Message
   end
 
+  test "to_struct returns an error tuple given a webhook notification with an unknown child type" do
+    res =
+      good_webhook_type()
+      |> Map.put("type", "message.created.not_a_real_type")
+      |> ExNylas.WebhookNotifications.to_struct()
+
+    assert match?({:error, _}, res)
+  end
+
   test "to_struct! transforms a raw webhook notification into an ExNylas struct" do
     res = ExNylas.WebhookNotifications.to_struct!(good_webhook_type())
     assert res.__struct__ == ExNylas.WebhookNotification


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified webhook notification logic by removing support for truncated message events.
	- Enhanced trigger processing for improved consistency in event handling.

- **Tests**
	- Added test cases to ensure correct transformation of specific webhook notification types into the appropriate message struct.
	- Included tests to verify error handling for unknown webhook notification types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->