### PR TITLE
Handle webhooks that are transformed and truncated

### DIFF
--- a/lib/ex_nylas/util/webhook_notifications/webhook_notification_data.ex
+++ b/lib/ex_nylas/util/webhook_notifications/webhook_notification_data.ex
@@ -90,6 +90,6 @@ defmodule ExNylas.WebhookNotificationData do
   end
 
   defp to_parent_trigger(trigger) when is_binary(trigger) do
-    String.replace(trigger, ~r/\.(truncated|transformed)$/, "")
+    String.replace(trigger, ~r/\.(truncated|transformed|transformed.truncated)$/, "")
   end
 end

--- a/test/util_test/webhook_notifications_test.exs
+++ b/test/util_test/webhook_notifications_test.exs
@@ -71,6 +71,15 @@ defmodule ExNylasTest.WebhookNotifications do
     assert res.data.object.__struct__ == ExNylas.Message
   end
 
+  test "to_struct transforms message.created.transformed.truncated into the correct parent type" do
+    {:ok, res} =
+      good_webhook_type()
+      |> Map.put("type", "message.created.transformed.truncated")
+      |> ExNylas.WebhookNotifications.to_struct()
+
+    assert res.data.object.__struct__ == ExNylas.Message
+  end
+
   test "to_struct returns an error tuple given a webhook notification with an unknown child type" do
     res =
       good_webhook_type()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced webhook notification processing to support additional trigger types, including `.transformed.truncated`.

- **Tests**
	- Added a new test case to verify correct transformation of specific webhook notification types into their corresponding structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->