### PR TITLE
Add mobile phone to contact and text desc to event

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         elixir: ['1.14', '1.15', '1.16', '1.17']
-        otp: ['24.0', '25.0', '26.0', '27.0']
+        otp: ['24.3', '25.3', '26.2', '27.0']
         exclude:
         - elixir: '1.14'
-          otp: '26.0'
+          otp: '26.2'
         - elixir: '1.14'
           otp: '27.0'
         - elixir: '1.15'
@@ -29,7 +29,7 @@ jobs:
         - elixir: '1.16'
           otp: '27.0'
         - elixir: '1.17'
-          otp: '24.0'
+          otp: '24.3'
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/ex_nylas/common/build/event_conferencing.ex
+++ b/lib/ex_nylas/common/build/event_conferencing.ex
@@ -12,7 +12,7 @@ defmodule ExNylas.Build.EventConferencing do
 
   typed_embedded_schema do
     field(:autocreate, :map)
-    field(:provider, Ecto.Enum, values: ~w('Google Meet' 'Microsoft Teams' 'Zoom Meeting')a, null: false)
+    field(:provider, Ecto.Enum, values: [:"Google Meet", :"Zoom Meeting", :"Microsoft Teams", :"Teams for Business", :"Skype for Consumer", :"Skype for Business"], null: false)
 
     embeds_one :details, Details, primary_key: false do
       @derive {Jason.Encoder, only: [:meeting_code, :password, :url, :phone, :pin]}

--- a/lib/ex_nylas/common/build/event_conferencing.ex
+++ b/lib/ex_nylas/common/build/event_conferencing.ex
@@ -12,7 +12,7 @@ defmodule ExNylas.Build.EventConferencing do
 
   typed_embedded_schema do
     field(:autocreate, :map)
-    field(:provider, Ecto.Enum, values: [:"Google Meet", :"Zoom Meeting", :"Microsoft Teams", :"Teams for Business", :"Skype for Consumer", :"Skype for Business"], null: false)
+    field(:provider, Ecto.Enum, values: [:"Google Meet", :"Zoom Meeting", :"Microsoft Teams", :"Teams for Business", :teamsForBusiness], null: false)
 
     embeds_one :details, Details, primary_key: false do
       @derive {Jason.Encoder, only: [:meeting_code, :password, :url, :phone, :pin]}

--- a/lib/ex_nylas/common/event_conferencing.ex
+++ b/lib/ex_nylas/common/event_conferencing.ex
@@ -11,7 +11,7 @@ defmodule ExNylas.EventConferencing do
 
   typed_embedded_schema do
     field(:autocreate, :map)
-    field(:provider, Ecto.Enum, values: ~w('Google Meet' 'Microsoft Teams' 'Zoom Meeting')a)
+    field(:provider, Ecto.Enum, values: [:"Google Meet", :"Zoom Meeting", :"Microsoft Teams", :"Teams for Business", :"Skype for Consumer", :"Skype for Business"], null: false)
 
     embeds_one :details, Details, primary_key: false do
       field(:meeting_code, :string)

--- a/lib/ex_nylas/contacts/build.ex
+++ b/lib/ex_nylas/contacts/build.ex
@@ -23,7 +23,7 @@ defmodule ExNylas.Contact.Build do
       @derive {Jason.Encoder, only: [:email, :type]}
 
       field(:email, :string, null: false)
-      field(:type, Ecto.Enum, values: ~w(work home other)a)
+      field(:type, Ecto.Enum, values: ~w(work home other mobile)a)
     end
 
     embeds_many :im_addresses, ImAddress, primary_key: false do

--- a/lib/ex_nylas/contacts/build.ex
+++ b/lib/ex_nylas/contacts/build.ex
@@ -23,7 +23,7 @@ defmodule ExNylas.Contact.Build do
       @derive {Jason.Encoder, only: [:email, :type]}
 
       field(:email, :string, null: false)
-      field(:type, Ecto.Enum, values: ~w(work home other mobile)a)
+      field(:type, Ecto.Enum, values: ~w(work home other)a)
     end
 
     embeds_many :im_addresses, ImAddress, primary_key: false do
@@ -37,7 +37,7 @@ defmodule ExNylas.Contact.Build do
       @derive {Jason.Encoder, only: [:number, :type]}
 
       field(:number, :string, null: false)
-      field(:type, Ecto.Enum, values: ~w(work home other)a)
+      field(:type, Ecto.Enum, values: ~w(work home other mobile)a)
     end
 
     embeds_many :web_pages, WebPage, primary_key: false do

--- a/lib/ex_nylas/contacts/schema.ex
+++ b/lib/ex_nylas/contacts/schema.ex
@@ -40,7 +40,7 @@ defmodule ExNylas.Contact do
 
     embeds_many :phone_numbers, PhoneNumber, primary_key: false do
       field(:number, :string)
-      field(:type, Ecto.Enum, values: ~w(work home other)a)
+      field(:type, Ecto.Enum, values: ~w(work home other mobile)a)
     end
 
     embeds_many :physical_addresses, PhysicalAddress, primary_key: false do

--- a/lib/ex_nylas/events/schema.ex
+++ b/lib/ex_nylas/events/schema.ex
@@ -26,6 +26,7 @@ defmodule ExNylas.Event do
           capacity: integer() | nil,
           created_at: integer() | nil,
           description: String.t() | nil,
+          text_description: String.t() | nil,
           hide_participants: boolean() | nil,
           grant_id: String.t() | nil,
           html_link: String.t() | nil,
@@ -101,6 +102,7 @@ defmodule ExNylas.Event do
     field(:read_only, :boolean)
     field(:recurrence, {:array, :string})
     field(:status, Ecto.Enum, values: ~w(confirmed canceled maybe)a)
+    field(:text_description, :string)
     field(:title, :string)
     field(:updated_at, :integer)
     field(:visibility, Ecto.Enum, values: ~w(public private default)a)
@@ -149,7 +151,7 @@ defmodule ExNylas.Event do
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:id, :grant_id, :calendar_id, :capacity, :busy, :created_at, :description, :hide_participants, :html_link, :ical_uid, :location, :master_event_id, :metadata, :object, :occurrences, :read_only, :recurrence, :status, :title, :updated_at, :visibility])
+    |> cast(params, [:id, :grant_id, :calendar_id, :capacity, :busy, :created_at, :description, :hide_participants, :html_link, :ical_uid, :location, :master_event_id, :metadata, :object, :occurrences, :read_only, :recurrence, :status, :text_description, :title, :updated_at, :visibility])
     |> cast_embed(:participants, with: &Util.embedded_changeset/2)
     |> cast_polymorphic_embed(:when)
     |> cast_embed(:conferencing, with: &conferencing_changeset/2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new field `text_description` to event details, enhancing event information.
	- Expanded the `type` field options for phone number schemas to include `mobile`.
	- Increased the options for the `provider` field in event conferencing to include `Teams for Business`, `Skype for Consumer`, and `Skype for Business`.

- **Bug Fixes**
	- Updated validation logic for the `type` field in phone number schemas to accommodate new values.
	- Adjusted the validation for the `provider` field in event conferencing to include additional options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->