### PR TITLE
Add raw mime to message.

### DIFF
--- a/lib/ex_nylas/messages/schema.ex
+++ b/lib/ex_nylas/messages/schema.ex
@@ -23,6 +23,7 @@ defmodule ExNylas.Message do
     field(:id, :string)
     field(:metadata, :map)
     field(:object, :string)
+    field(:raw_mime, :string)
     field(:schedule_id, :string)
     field(:snippet, :string)
     field(:starred, :boolean)
@@ -42,7 +43,7 @@ defmodule ExNylas.Message do
   @doc false
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:body, :date, :folders, :grant_id, :id, :object, :snippet, :starred, :subject, :thread_id, :unread, :metadata, :schedule_id, :conversation])
+    |> cast(params, [:body, :date, :folders, :grant_id, :id, :object, :snippet, :starred, :subject, :thread_id, :unread, :metadata, :schedule_id, :conversation, :raw_mime])
     |> cast_embed(:bcc)
     |> cast_embed(:cc)
     |> cast_embed(:attachments)


### PR DESCRIPTION
Hey @nicholasbair , how is it going?

I'm not sure if you're interested in supporting it or not, but we've been fetching the raw_mime of a few messages for some debugging purposes.
I noticed that it was not being casted to the message struct if one were to query for `fields=raw_mime` when fetching messages, so this PR adds that.


As usual, thanks again for your great work on this library and feel free to ignore this.

Cheers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for raw MIME content in messages. This enhancement allows additional email data to be captured and processed during message creation and updates, ensuring a more comprehensive handling of email details and improved data integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->