### PR TITLE
Add OAuth token refresh functionality to Grants module

### DIFF
--- a/lib/ex_nylas/grants/grants.ex
+++ b/lib/ex_nylas/grants/grants.ex
@@ -49,4 +49,61 @@ defmodule ExNylas.Grants do
       {:error, response} -> raise ExNylasError, response
     end
   end
+
+  @doc """
+  Refresh a grant's access token using its refresh token.
+  
+  OAuth 2.0 access tokens expire after one hour. When the access token expires, 
+  you can use the refresh token to get a new access token.
+
+  ## Examples
+
+      iex> {:ok, result} = ExNylas.Grants.refresh(conn, "refresh-token")
+  """
+  @spec refresh(Conn.t(), String.t()) :: {:ok, Response.t()} | {:error, Response.t()}
+  def refresh(%Conn{} = conn, refresh_token) do
+    body = %{
+      client_id: conn.client_id,
+      client_secret: conn.api_key,
+      grant_type: "refresh_token",
+      refresh_token: refresh_token
+    }
+
+    Req.new(
+      url: "#{conn.api_server}/v3/connect/token",
+      headers: API.base_headers(),
+      json: body
+    )
+    |> API.maybe_attach_telemetry(conn)
+    |> Req.post(conn.options)
+    |> conditional_transform()
+  end
+
+  @doc """
+  Refresh a grant's access token using its refresh token.
+  
+  OAuth 2.0 access tokens expire after one hour. This function will raise an error
+  if the refresh operation fails.
+
+  ## Examples
+
+      iex> result = ExNylas.Grants.refresh!(conn, "refresh-token")
+  """
+  @spec refresh!(Conn.t(), String.t()) :: Response.t()
+  def refresh!(%Conn{} = conn, refresh_token) do
+    case refresh(conn, refresh_token) do
+      {:ok, response} -> response
+      {:error, response} -> raise ExNylasError, response
+    end
+  end
+  
+  # The response from the API differs based on whether the request was successful or not
+  # Pass the correct schema name to transform based on the response status
+  defp conditional_transform({:ok, %{status: 200}} = res) do
+    API.handle_response(res, ExNylas.HostedAuthentication.Grant, false)
+  end
+
+  defp conditional_transform(res) do
+    API.handle_response(res)
+  end
 end

--- a/test/interface_tests/grants_test.exs
+++ b/test/interface_tests/grants_test.exs
@@ -7,6 +7,9 @@ defmodule ExNylasTest.Grants do
     Response,
     Connection
   }
+  
+  # ExNylasError is defined at the top level
+  alias ExNylasError
 
   setup do
     bypass = Bypass.open()
@@ -80,6 +83,96 @@ defmodule ExNylasTest.Grants do
 
     assert_raise ExNylasError, fn ->
       Grants.me!(conn)
+    end
+  end
+
+  test "refresh/2 returns new token on success", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/v3/connect/token", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.send_resp(200, ~s<{
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "scope": "https://www.googleapis.com/auth/gmail.readonly profile",
+        "token_type": "Bearer",
+        "id_token": "id-token",
+        "grant_id": "grant-id"
+      }>)
+    end)
+
+    conn = %Connection{
+      api_server: endpoint_url(bypass.port),
+      client_id: "client-id",
+      api_key: "api-key",
+      options: []
+    }
+
+    assert {:ok, grant} = Grants.refresh(conn, "refresh-token")
+    assert grant.access_token == "new-access-token"
+    assert grant.refresh_token == "new-refresh-token"
+    assert grant.grant_id == "grant-id"
+  end
+
+  test "refresh/2 returns error on failure", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/v3/connect/token", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.send_resp(400, ~s<{"error": "invalid_grant", "error_description": "Refresh token invalid"}>)
+    end)
+
+    conn = %Connection{
+      api_server: endpoint_url(bypass.port),
+      client_id: "client-id",
+      api_key: "api-key",
+      options: []
+    }
+
+    assert {:error, %Response{status: :bad_request}} = Grants.refresh(conn, "invalid-refresh-token")
+  end
+
+  test "refresh!/2 returns new token on success", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/v3/connect/token", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.send_resp(200, ~s<{
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "scope": "https://www.googleapis.com/auth/gmail.readonly profile",
+        "token_type": "Bearer",
+        "id_token": "id-token",
+        "grant_id": "grant-id"
+      }>)
+    end)
+
+    conn = %Connection{
+      api_server: endpoint_url(bypass.port),
+      client_id: "client-id",
+      api_key: "api-key",
+      options: []
+    }
+
+    assert grant = Grants.refresh!(conn, "refresh-token")
+    assert grant.access_token == "new-access-token"
+    assert grant.refresh_token == "new-refresh-token"
+    assert grant.grant_id == "grant-id"
+  end
+
+  test "refresh!/2 raises error on failure", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/v3/connect/token", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.send_resp(400, ~s<{"error": "invalid_grant", "error_description": "Refresh token invalid"}>)
+    end)
+
+    conn = %Connection{
+      api_server: endpoint_url(bypass.port),
+      client_id: "client-id",
+      api_key: "api-key",
+      options: []
+    }
+
+    assert_raise ExNylasError, fn ->
+      Grants.refresh!(conn, "invalid-refresh-token")
     end
   end
 end


### PR DESCRIPTION
Implements support for refreshing expired OAuth 2.0 access tokens:
- Add refresh/2 and refresh\!/2 functions to obtain new access tokens using refresh tokens
- Uses conditional_transform pattern to properly handle token endpoint responses
- Add comprehensive test coverage for both success and error cases
- Follow Nylas API documentation for token refresh endpoint (/v3/connect/token)

This completes support for the full OAuth 2.0 token lifecycle, allowing applications to refresh tokens instead of requiring users to re-authenticate when tokens expire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced robust OAuth 2.0 token refresh functionality to ensure seamless session continuity and improved error handling.

- **Tests**
  - Expanded test coverage validating both successful and failure scenarios for token refresh operations to ensure reliable session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->