### PR TITLE
Add changelog link to Hex package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,8 @@ defmodule ExNylas.MixProject do
       name: "ex_nylas",
       licenses: ["MIT"],
       links: %{
-        "GitHub" => url(),
+        "Changelog" => "#{url()}/blob/main/CHANGELOG.md",
+        "GitHub" => url()
       }
     ]
   end


### PR DESCRIPTION
Adds a Changelog link to the package metadata that will display on hex.pm. This makes it easier for users to find version history directly from the package page.

The changelog link points to the CHANGELOG.md file in the GitHub repository using the existing url() function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a "Changelog" link to the package information, making it easier to access the project's changelog from package listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->